### PR TITLE
image pull secrets

### DIFF
--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -66,3 +66,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -9,6 +9,13 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 ## Set these values to correspond to the JupyterHub setup
 # jupyterhub_api_token: notebookstoken
 # jupyterhub_base_url: /


### PR DESCRIPTION
This PR adds the possibility to use a private registry for the `renku-notebooks` image.

Private image example:
https://gitlab.com/renku/renku-notebooks/container_registry
then:
```bash
$ helm upgrade -i renku-notebooks \
    --namespace test \
    --set image.repository="registry.gitlab.com/renku/renku-notebooks" \
    --set image.tag="pull-secrets" renku-notebooks \
    --set global.renku.domain=$(minikube ip)
```

You will see the image pull fail.
```bash
$ kubectl -n test create secret docker-registry regcred \
    --docker-server=registry.gitlab.com \
    --docker-username="gitlab+deploy-token-5965" \
    --docker-password="***" \
    --docker-email="***"
$ helm upgrade -i renku-notebooks \
    --namespace test \
    --set image.repository="registry.gitlab.com/renku/renku-notebooks" \
    --set image.tag="pull-secrets" renku-notebooks \
    --set global.renku.domain=$(minikube ip) \
    --set "image.pullSecrets[0]=regcred"
```

---
addresses https://github.com/SwissDataScienceCenter/renku/issues/176 and https://github.com/SwissDataScienceCenter/renku/issues/276