### PR TITLE
open the notebook in jupyterlab

### DIFF
--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -116,7 +116,7 @@ def _notebook_url(user, server_name, notebook=None):
         )
     )
     if notebook:
-        notebook_url += '/notebooks/{notebook}'.format(notebook=notebook)
+        notebook_url += 'lab/tree/{notebook}'.format(notebook=notebook)
     return notebook_url
 
 


### PR DESCRIPTION
closes #27 

~~This has the side-effect of JupyterLab messing up the URL. The server starts and opens fine with the correct notebook displayed, but the URL gets changed to `<host>/lab/jupyterhub/user/<user>/<server-name>` instead of keeping `<host>/jupyterhub/user/<user>/<server-name>/lab`~~

The incorrect redirect seems to have been caused by an extra slash in the URL... 

This also resolves https://github.com/SwissDataScienceCenter/renku-ui/issues/273