### PR TITLE
Enable RStudio launches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.1 as react-builder
+FROM node:8.11.1-alpine as react-builder
 
 # Uncomment the following line to allow live updating of files for development.
 # ADD . /app

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -24,7 +24,7 @@ charts:
         contextPath: ../singleuser
         buildArgs:
           JUPYTERHUB_VERSION: "0.9.2"
-          RENKU_VERSION: "0.2.0rc1"
+          RENKU_VERSION: "0.2.0"
         dockerfilePath: ../singleuser/Dockerfile
         valuesPath: jupyterhub.singleuser.image
         paths:

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -34,7 +34,7 @@ charts:
         contextPath: ../singleuser
         buildArgs:
           JUPYTERHUB_VERSION: "0.9.2"
-          RENKU_VERSION: "0.2.0rc1"
+          RENKU_VERSION: "0.2.0"
         dockerfilePath: ../singleuser/R.Dockerfile
         valuesPath: jupyterhub.singleuser-r.image
         paths:

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -30,3 +30,13 @@ charts:
         paths:
           - ../singleuser
           - ..
+      singleuser-r:
+        contextPath: ../singleuser
+        buildArgs:
+          JUPYTERHUB_VERSION: "0.9.2"
+          RENKU_VERSION: "0.2.0rc1"
+        dockerfilePath: ../singleuser/R.Dockerfile
+        valuesPath: jupyterhub.singleuser-r.image
+        paths:
+          - ../singleuser
+          - ..

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -28,34 +28,36 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: DEFAULT_NOTEBOOK_IMAGE
+              value: "{{ .Values.jupyterhub.singleuser.image.name }}:{{ .Values.jupyterhub.singleuser.image.tag }}"
             {{ if eq .Values.debug true }}
             - name: FLASK_DEBUG
               value: "1"
             {{ end }}
             - name: JUPYTERHUB_API_TOKEN
-              value: {{ .Values.jupyterhub_api_token }}
+              value: {{ .Values.jupyterhub.hub.services.notebooks.api_token }}
             - name: JUPYTERHUB_API_URL
-            {{ if .Values.jupyterhub_api_url }}
-              value: {{ .Values.jupyterhub_api_url }}
-            {{ else }}
-              value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain }}{{ .Values.jupyterhub_base_url }}hub/api
-            {{ end }}
+              value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain }}{{ .Values.jupyterhub.hub.baseUrl }}hub/api
+            - name: JUPYTERHUB_SINGLEUSER_DEFAULT_URL
+              value: {{ .Values.jupyterhub.singleuser.defaultUrl }}
             - name: JUPYTERHUB_SERVICE_PREFIX
-              value: {{ .Values.jupyterhub_base_url }}services/notebooks/
+              value: {{ .Values.jupyterhub.hub.baseUrl }}services/notebooks/
             - name: JUPYTERHUB_BASE_URL
-              value: {{ .Values.jupyterhub_base_url }}
+              value: {{ .Values.jupyterhub.hub.baseUrl }}
             - name: JUPYTERHUB_CLIENT_ID
               value: {{ .Values.jupyterhub.hub.services.notebooks.oauth_client_id }}
             - name: GITLAB_REGISTRY_SECRET
               value: {{ template "renku.fullname" . }}-registry
             - name: GITLAB_URL
-            {{ if .Values.gitlab_url }}
-              value: {{ .Values.gitlab_url }}
+            {{ if .Values.gitlab.url }}
+              value: {{ .Values.gitlab.url }}
             {{ else }}
-              value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain}}/gitlab
+              value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain}}{{ .Values.global.gitlab.urlPrefix }}
             {{ end }}
+            - name: IMAGE_BUILD_TIMEOUT
+              value: "{{ .Values.imageBuildTimeout }}"
             - name: IMAGE_REGISTRY
-              value: {{ .Values.imageRegistry }}
+              value: {{required "An image registry must be specified." .Values.imageRegistry }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
             {{ else }}
               value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain}}/gitlab
             {{ end }}
+            - name: IMAGE_REGISTRY
+              value: {{ .Values.imageRegistry }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
               value: {{ .Values.jupyterhub.hub.services.notebooks.oauth_client_id }}
             - name: GITLAB_REGISTRY_SECRET
               value: {{ template "renku.fullname" . }}-registry
+            - name: GITLAB_URL
+            {{ if .Values.gitlab_url }}
+              value: {{ .Values.gitlab_url }}
+            {{ else }}
+              value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain}}/gitlab
+            {{ end }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
             - name: FLASK_DEBUG
               value: "1"
             {{ end }}
+            {{ if .Values.jupyterhub.singleuser.defaultUrl }}
+            - name: JUPYTER_DEFAULT_URL
+              value: {{ .Values.jupyterhub.singleuser.defaultUrl }}
+            {{ end }}
             - name: JUPYTERHUB_API_TOKEN
               value: {{ .Values.jupyterhub.hub.services.notebooks.api_token }}
             - name: JUPYTERHUB_API_URL

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -35,15 +35,13 @@ spec:
               value: "1"
             {{ end }}
             {{ if .Values.jupyterhub.singleuser.defaultUrl }}
-            - name: JUPYTER_DEFAULT_URL
+            - name: JUPYTERHUB_SINGLEUSER_DEFAULT_URL
               value: {{ .Values.jupyterhub.singleuser.defaultUrl }}
             {{ end }}
             - name: JUPYTERHUB_API_TOKEN
               value: {{ .Values.jupyterhub.hub.services.notebooks.api_token }}
             - name: JUPYTERHUB_API_URL
               value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain }}{{ .Values.jupyterhub.hub.baseUrl }}hub/api
-            - name: JUPYTERHUB_SINGLEUSER_DEFAULT_URL
-              value: {{ .Values.jupyterhub.singleuser.defaultUrl }}
             - name: JUPYTERHUB_SERVICE_PREFIX
               value: {{ .Values.jupyterhub.hub.baseUrl }}services/notebooks/
             - name: JUPYTERHUB_BASE_URL

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -5,6 +5,10 @@
 global:
   useHTTPS: false
 
+  ## specify the GitLab instance URL
+  # gitlab:
+  #   url:
+
 replicaCount: 1
 
 image:
@@ -89,8 +93,6 @@ jupyterhub:
     extraEnv:
       DEBUG: 1
       JUPYTERHUB_SPAWNER_CLASS: spawners.RenkuKubeSpawner
-      ## timeout for waiting on an image build
-      # GITLAB_IMAGE_BUILD_TIMEOUT: 600
       ## GitLab instance URL
       # GITLAB_URL: http://gitlab.com
     extraConfig: |

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -23,10 +23,8 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## Set these values to correspond to the JupyterHub setup
-# jupyterhub_api_token: notebookstoken
-# jupyterhub_base_url: /
-# jupyterhub_api_url: http://<host>/hub/api
+## Set the default image registry
+# imageRegistry:
 
 ## Set the default image registry
 # imageRegistry:
@@ -149,6 +147,10 @@ jupyterhub:
     storage:
       type: none
     defaultUrl: /lab
+  singleuser-r:
+    image:
+      name: renku/singleuser-r
+      tag: 'latest'
   # FIXME: bug in prepuller makes helm hang in certain cases. Fixed in 0.7
   # so this should be removed eventually.
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/477

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -26,9 +26,6 @@ image:
 ## Set the default image registry
 # imageRegistry:
 
-## Set the default image registry
-# imageRegistry:
-
 ## set the image build timeout
 imageBuildTimeout: '600'
 

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -5,9 +5,9 @@
 global:
   useHTTPS: false
 
+gitlab:
   ## specify the GitLab instance URL
-  # gitlab:
-  #   url:
+  url:
 
 replicaCount: 1
 
@@ -30,6 +30,9 @@ image:
 
 ## Set the default image registry
 # imageRegistry:
+
+## set the image build timeout
+imageBuildTimeout: '600'
 
 # enable the security context - if using telepresence for development, disable it
 securityContext:

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -28,6 +28,9 @@ image:
 # jupyterhub_base_url: /
 # jupyterhub_api_url: http://<host>/hub/api
 
+## Set the default image registry
+# imageRegistry:
+
 # enable the security context - if using telepresence for development, disable it
 securityContext:
   enabled: true

--- a/jupyterhub/jupyterhub-k8s.Dockerfile
+++ b/jupyterhub/jupyterhub-k8s.Dockerfile
@@ -1,9 +1,9 @@
-FROM jupyterhub/k8s-hub:bf3550b
+FROM jupyterhub/k8s-hub:0.7.0
 
 USER root
 
-COPY requirements-k8s.txt /tmp/requirements.renku.txt
-RUN pip3 install -r /tmp/requirements.renku.txt --no-cache-dir
+COPY requirements-k8s.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
 
 COPY spawners.py /usr/local/lib/python3.6/dist-packages/
 

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -95,6 +95,7 @@ class SpawnerMixin():
         commit_sha = options.get('commit_sha')
         commit_sha_7 = commit_sha[:7]
         self.image = options.get('image')
+        self.default_url = options.get('default_url')
 
         url = os.getenv('GITLAB_URL', 'http://gitlab.renku.build')
 

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -291,6 +291,9 @@ try:
             # set the notebook container image
             self.image_spec = self.image
 
+            # set the default url
+            self.default_url = options.get('default_url')
+
             #: Define a new empty volume.
             self.volumes = [
                 volume for volume in self.volumes if volume['name'] != volume_name

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -292,9 +292,6 @@ try:
             # set the notebook container image
             self.image_spec = self.image
 
-            # set the default url
-            self.default_url = options.get('default_url')
-
             #: Define a new empty volume.
             self.volumes = [
                 volume for volume in self.volumes if volume['name'] != volume_name

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -1,12 +1,12 @@
 # Build as renku/singleuser
 # Run with the DockerSpawner in JupyterHub
 
-ARG JUPYTERHUB_VERSION=0.9
+ARG JUPYTERHUB_VERSION=0.9.2
 ARG BASE_IMAGE=jupyterhub/singleuser:$JUPYTERHUB_VERSION
 
 FROM $BASE_IMAGE
 ARG JUPYTERHUB_VERSION
-ARG RENKU_VERSION=0.2.0rc1
+ARG RENKU_VERSION=0.2.0
 MAINTAINER Swiss Data Science Center <info@datascience.ch>
 
 
@@ -33,8 +33,10 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
 USER $NB_USER
 
 # install jupyterlab, papermill, git extension and renku-jupyterlab-ts
+COPY requirements.txt /tmp/requirements.txt
+
 RUN python3 -m pip install -U pip && \
-    pip install -U jupyterlab papermill && \
+    pip install -r /tmp/requirements.txt && \
     jupyter labextension update @jupyterlab/hub-extension --no-build && \
     jupyter labextension install @jupyterlab/git --no-build && \
     jupyter labextension install renku-jupyterlab-ts --no-build && \

--- a/singleuser/R.Dockerfile
+++ b/singleuser/R.Dockerfile
@@ -1,0 +1,69 @@
+ARG BASE_IMAGE=renku/singleuser:latest
+
+FROM $BASE_IMAGE
+
+MAINTAINER Swiss Data Science Center <info@datascience.ch>
+
+USER root
+
+# R pre-requisites
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    fonts-dejavu \
+    tzdata \
+    gfortran \
+    libapparmor1 \
+    libedit2 \
+    lsb-release \
+    psmisc \
+    libssl1.0.0 \
+    gcc && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# You can use rsession from rstudio's desktop package as well.
+ENV RSTUDIO_PKG=rstudio-server-1.0.136-amd64.deb
+
+RUN wget -q http://download2.rstudio.org/${RSTUDIO_PKG}
+RUN dpkg -i ${RSTUDIO_PKG}
+RUN rm ${RSTUDIO_PKG}
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $NB_USER
+
+# R packages
+RUN conda install --quiet --yes \
+    'r-base=3.4.1' \
+    'r-irkernel=0.8*' \
+    'r-plyr=1.8*' \
+    'r-devtools=1.13*' \
+    'r-tidyverse=1.1*' \
+    'r-shiny=1.0*' \
+    'r-rmarkdown=1.8*' \
+    'r-forecast=8.2*' \
+    'r-rsqlite=2.0*' \
+    'r-reshape2=1.4*' \
+    'r-nycflights13=0.2*' \
+    'r-caret=6.0*' \
+    'r-rcurl=1.95*' \
+    'r-crayon=1.3*' \
+    'r-randomforest=4.6*' \
+    'r-htmltools=0.3*' \
+    'r-sparklyr=0.7*' \
+    'r-htmlwidgets=1.0*' \
+    'r-hexbin=1.27*' && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR
+
+# install R Jupyter extension
+RUN pip install git+https://github.com/jupyterhub/nbserverproxy.git && \
+    jupyter serverextension enable --sys-prefix --py nbserverproxy && \
+    pip install git+https://github.com/jupyterhub/nbrsessionproxy.git && \
+    jupyter serverextension enable --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension install    --sys-prefix --py nbrsessionproxy && \
+    jupyter nbextension enable     --sys-prefix --py nbrsessionproxy
+
+# The desktop package uses /usr/lib/rstudio/bin
+ENV PATH="${PATH}:/usr/lib/rstudio-server/bin"
+ENV LD_LIBRARY_PATH="/usr/lib/R/lib:/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:/opt/conda/lib/R/lib"

--- a/singleuser/requirements.txt
+++ b/singleuser/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab==0.34.0
+papermill

--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -383,8 +383,10 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
     headers = {auth.auth_header_name: 'token {0}'.format(auth.api_token)}
 
     # if there is an image passed with the request, use it
-    image = request.args.get(
-        'image', get_notebook_image(user, namespace, project, commit_sha)
+    image = get_notebook_image(user, namespace, project, commit_sha)
+
+    default_url = request.args.get(
+        'default_url', os.environ.get('JUPYTERHUB_SINGLEUSER_DEFAULT_URL')
     )
 
     payload = {
@@ -394,6 +396,7 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
         'notebook': notebook,
         'project': project,
         'image': image,
+        'default_url': default_url,
     }
     if os.environ.get('GITLAB_REGISTRY_SECRET'):
         payload['image_pull_secrets'] = payload.get('image_pull_secrets', [])

--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -260,9 +260,10 @@ def get_notebook_image(user, namespace, project, commit_sha):
     gl_project = get_gitlab_project(user, namespace, project)
 
     # image build timeout -- configurable, defaults to 10 minutes
-    image_build_timeout = int(os.getenv('GITLAB_IMAGE_BUILD_TIMEOUT', 600))
+    image_build_timeout = int(os.getenv('IMAGE_BUILD_TIMEOUT', 600))
 
-    image = 'renku/singleuser:latest'
+    image = os.getenv('DEFAULT_NOTEBOOK_IMAGE', 'renku/singleuser:latest')
+
     commit_sha_7 = commit_sha[:7]
 
     for pipeline in gl_project.pipelines.list():

--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -43,6 +43,9 @@ ANNOTATION_PREFIX = 'hub.jupyter.org'
 GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
 """The GitLab instance to use."""
 
+IMAGE_REGISTRY = os.environ.get('IMAGE_REGISTRY', '')
+"""The default image registry."""
+
 SERVER_STATUS_MAP = {'spawn': 'spawning', 'stop': 'stopping'}
 
 # check if we are running on k8s
@@ -277,7 +280,7 @@ def get_notebook_image(user, namespace, project, commit_sha):
                 # it *should* be there so lets use it
                 image = '{image_registry}/{namespace}'\
                         '/{project}:{commit_sha_7}'.format(
-                                image_registry=os.getenv('IMAGE_REGISTRY'),
+                                image_registry=IMAGE_REGISTRY,
                                 commit_sha_7=commit_sha_7,
                                 namespace=namespace,
                                 project=project
@@ -378,6 +381,7 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
     # 1. launch using spawner that checks the access
     headers = {auth.auth_header_name: 'token {0}'.format(auth.api_token)}
 
+    # if there is an image passed with the request, use it
     image = request.args.get(
         'image', get_notebook_image(user, namespace, project, commit_sha)
     )

--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -389,6 +389,10 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
         'default_url', os.environ.get('JUPYTERHUB_SINGLEUSER_DEFAULT_URL')
     )
 
+    default_url = request.args.get(
+        'default_url', os.environ.get('JUPYTER_DEFAULT_URL')
+    )
+
     payload = {
         'branch': request.args.get('branch', 'master'),
         'commit_sha': commit_sha,

--- a/src/notebooks_service.py
+++ b/src/notebooks_service.py
@@ -389,10 +389,6 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
         'default_url', os.environ.get('JUPYTERHUB_SINGLEUSER_DEFAULT_URL')
     )
 
-    default_url = request.args.get(
-        'default_url', os.environ.get('JUPYTER_DEFAULT_URL')
-    )
-
     payload = {
         'branch': request.args.get('branch', 'master'),
         'commit_sha': commit_sha,


### PR DESCRIPTION
This PR enables RStudio launches from renku. 

* creates a renku-enabled rstudio image that is compatible with jupyter (based on the  `nbrsessionproxy` `Dockerfile`)
* adds the ability to specify `default_url` as a query parameter. If the `POST` request includes `?default_url=/rstudio` in the request url, RStudio is launched automatically. This should be included in the UI as part of https://github.com/SwissDataScienceCenter/renku-ui/issues/308.

closes #57 