### PR TITLE
Update chartpress

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -19,7 +19,6 @@ charts:
         valuesPath: jupyterhub.hub.image
         paths:
           - ../jupyterhub
-          - ..
       singleuser:
         contextPath: ../singleuser
         buildArgs:
@@ -29,7 +28,6 @@ charts:
         valuesPath: jupyterhub.singleuser.image
         paths:
           - ../singleuser
-          - ..
       singleuser-r:
         contextPath: ../singleuser
         buildArgs:
@@ -38,7 +36,6 @@ charts:
         valuesPath: jupyterhub.singleuser-r.image
         paths:
           - ../singleuser
-          - ..
       singleuser-cuda-9.2:
         contextPath: ../singleuser
         buildArgs:
@@ -47,4 +44,3 @@ charts:
         valuesPath: jupyterhub.singleuser-cuda-9-2.image
         paths:
           - ../singleuser
-          - ..

--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -1,3 +1,30 @@
+serverOptions:
+  cpu_request:
+    displayName: CPU request
+    type: enum
+    default: 0.1
+    options: [0.1, 0.5, 1.0, 2.0, 4.0]
+  mem_request:
+    displayName: Memory request
+    type: enum
+    default: 1G
+    options: [1G, 2G, 4G]
+  gpu_request:
+    displayName: GPU request
+    type: int
+    default: 0
+    range: [0, ]
+  defaultUrl:
+    displayName: default landing URL of the notebook server
+    type: enum
+    default: /lab
+    options: [/lab]
+  lfs_auto_fetch:
+    displayName: Automatically fetch LFS data
+    type: boolean
+    default: false
+
+
 jupyterhub:
   rbac:
     enabled: true


### PR DESCRIPTION
remove the dependency of image builds on the entire `renku-notebooks` directory. This should result in fewer image builds. 