### PR TITLE
build(helm): extra config map with env for KubeSpawner

### DIFF
--- a/helm-chart/renku-notebooks/templates/configmap.yaml
+++ b/helm-chart/renku-notebooks/templates/configmap.yaml
@@ -11,3 +11,15 @@ metadata:
 data:
   server_options.json: |
     {{ toJson .Values.serverOptions }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hub-config-spawner
+  labels:
+    app: {{ template "notebooks.name" . }}
+    chart: {{ template "notebooks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  SENTRY_DSN: {{ .Values.jupyterhub.singleuser.sentryDsn }}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -162,6 +162,15 @@ jupyterhub:
       # Increase pod initialization timeout to 15 minutes
       c.KubeSpawner.start_timeout = 60 * 15
 
+      # Pass extra configuration using config map
+      c.KubeSpawner.extra_container_config = {
+          'envFrom': [{
+              'configMapRef': {
+                  'name': 'hub-config-spawner'
+              }
+          }]
+      }
+
       # prevent redirect to /hub if the server is taking slightly longer to start
       c.JupyterHub.tornado_settings = {
         'slow_spawn_timeout': 1
@@ -174,6 +183,7 @@ jupyterhub:
     storage:
       type: none
     defaultUrl: /lab
+    sentryDsn: ''
   # FIXME: bug in prepuller makes helm hang in certain cases. Fixed in 0.7
   # so this should be removed eventually.
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/477


### PR DESCRIPTION
Adds option to include `SENTRY_DSN` configuration.