### PR TITLE
fix: remove imageBuildTimeout

### DIFF
--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -63,8 +63,6 @@ spec:
             {{ else }}
               value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain}}{{ .Values.global.gitlab.urlPrefix }}
             {{ end }}
-            - name: IMAGE_BUILD_TIMEOUT
-              value: "{{ .Values.imageBuildTimeout }}"
             - name: IMAGE_REGISTRY
               value: {{ required "An image registry must be specified." .Values.gitlab.registry.host }}
             - name: GIT_CLONE_IMAGE

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -33,9 +33,6 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## set the image build timeout
-imageBuildTimeout: '600'
-
 # enable the security context - if using telepresence for development, disable it
 securityContext:
   enabled: true


### PR DESCRIPTION
We should not be doing these checks in the notebooks service,
but instead in the frontend. The notebooks service should just
launch whatever image it's given.

closes #70