### PR TITLE
build: fix jh version

### DIFF
--- a/jupyterhub/requirements.txt
+++ b/jupyterhub/requirements.txt
@@ -18,5 +18,5 @@
 
 # Installing from Git until a new version of kubespawner (introducing 'delete_grace_period') is released.
 -e git://github.com/jupyterhub/kubespawner.git@46a4b109c5e657a4c3d5bfa8ea4731ec6564ea13#egg=jupyterhub-kubespawner
-jupyterhub>=0.9.6
+jupyterhub==0.9.6
 python-gitlab


### PR DESCRIPTION
The requirements file had `>=0.9.6` meaning that the image built by travis had JH 1.0.0 instead of 0.9.6. Keep this one until we've done some more testing. 