### PR TITLE
refactor(charts): move registry secret from renku repo

### DIFF
--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -55,9 +55,9 @@ spec:
               value: {{ template "notebooks.http" . }}://{{ .Values.global.renku.domain }}
             - name: JUPYTERHUB_CLIENT_ID
               value: {{ .Values.jupyterhub.hub.services.notebooks.oauth_client_id }}
-            {{ if .Values.gitlab.registry.secret }}
+            {{ if and .Values.gitlab.registry.username .Values.gitlab.registry.token }}
             - name: GITLAB_REGISTRY_SECRET
-              value: {{ .Values.gitlab.registry.secret }}
+              value: {{ template "notebooks.fullname" . }}-registry
             {{ end }}
             - name: GITLAB_URL
             {{ if .Values.gitlab.url }}

--- a/helm-chart/renku-notebooks/templates/registry-secret.yaml
+++ b/helm-chart/renku-notebooks/templates/registry-secret.yaml
@@ -1,0 +1,15 @@
+{{- $auth := printf "%s:%s" .Values.gitlab.registry.username .Values.gitlab.registry.token | b64enc -}}
+{{- $registry := .Values.gitlab.registry.host | replace "http://" "" | replace "https://" "" | replace ":443" "" -}}
+{{- $secret := printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"root@example.com\",\"auth\":\"%s\"}}}" $registry .Values.gitlab.registry.username .Values.gitlab.registry.token $auth -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ template "notebooks.fullname" . }}-registry
+  labels:
+    app: {{ template "notebooks.name" . }}
+    chart: {{ template "notebooks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  .dockerconfigjson: {{ $secret | b64enc | quote }}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -13,8 +13,10 @@ gitlab:
   registry:
     ## Set the default image registry
     host:
-    ## Set the registry secret key
-    secret:
+    ## Username and token are used for creating a secret for pulling private docker images.
+    ## This combination therefore must give access to private projects, so it should be an admin.
+    # username:
+    # token:
 
 ## For sending exceptions to Sentry, specify the DSN to use
 # sentryDsn:


### PR DESCRIPTION
Note that this change allows non-root admin tokens to be used. This should make it easier to rotate them periodically. 

```
gitlab:
  registry:
    username: a_user
    token: 12345
```

closes #167