### PR TITLE
fix: update registry secret template

### DIFF
--- a/helm-chart/renku-notebooks/templates/registry-secret.yaml
+++ b/helm-chart/renku-notebooks/templates/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.gitlab.registry.username .Values.gitlab.registry.token }}
 {{- $auth := printf "%s:%s" .Values.gitlab.registry.username .Values.gitlab.registry.token | b64enc -}}
 {{- $registry := .Values.gitlab.registry.host | replace "http://" "" | replace "https://" "" | replace ":443" "" -}}
 {{- $secret := printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"root@example.com\",\"auth\":\"%s\"}}}" $registry .Values.gitlab.registry.username .Values.gitlab.registry.token $auth -}}
@@ -13,3 +14,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   .dockerconfigjson: {{ $secret | b64enc | quote }}
+{{- end }}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -6,6 +6,8 @@ global:
   useHTTPS: false
   gitlab:
     urlPrefix: /
+  renku:
+    domain:
 
 gitlab:
   ## specify the GitLab instance URL


### PR DESCRIPTION
Quick fix for the newly-refactored secret - ignore the secret template if the username *and* token are not set. 