### PR TITLE
chore: use pre-commit hooks for chartpress --reset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
     rev: v1.2.3
     hooks:
     - id: flake8
+-   repo: local
+    hooks:
+    - id: chartpress
+      name: chartpress reset
+      files: helm-chart/*
+      description: Run `chartpress --reset` to clean up helm charts before committing.
+      entry: pipenv run chartpress --reset
+      language: system
+      pass_filenames: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,9 @@ script:
   - echo "building renku-notebooks"
   - docker build .
   - helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-  - cd helm-chart
-  - helm dependency update renku-notebooks
+  - helm dependency update helm-chart/renku-notebooks
   - chartpress
-  - cd ..
+
 
 deploy:
   - &script

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,32 +1,32 @@
 charts:
-  - name: renku-notebooks
+  - name: helm-chart/renku-notebooks
     resetTag: latest
     imagePrefix: renku/
     repo:
       git: SwissDataScienceCenter/helm-charts
       published: https://swissdatasciencecenter.github.io/helm-charts
     paths:
-      - ..
-      - ../jupyterhub
-      - ../singleuser
+      - .
+      - jupyterhub
+      - singleuser
     images:
       renku-notebooks:
-        contextPath: ..
-        dockerfilePath: ../Dockerfile
+        contextPath: .
+        dockerfilePath: Dockerfile
         valuesPath: image
       jupyterhub-k8s:
         buildArgs:
           K8S_HUB_VERSION: 0.9-174bbd5
-        contextPath: ../jupyterhub
-        dockerfilePath: ../jupyterhub/Dockerfile
+        contextPath: jupyterhub
+        dockerfilePath: jupyterhub/Dockerfile
         valuesPath: jupyterhub.hub.image
         paths:
-          - ../jupyterhub
+          - jupyterhub
       git-clone:
         buildArgs:
           GIT_ALPINE_VERSION: 1.0.7
-        contextPath: ../git-clone
-        dockerfilePath: ../git-clone/Dockerfile
+        contextPath: git-clone
+        dockerfilePath: git-clone/Dockerfile
         valuesPath: git_clone.image
         paths:
-          - ../git-clone
+          - git-clone

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -29,8 +29,7 @@ make login
 # build charts/images and push
 helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 helm repo update
-cd helm-chart
-helm dependency update renku-notebooks
+helm dependency update helm-chart/renku-notebooks
 chartpress --push --publish-chart
 git diff
 
@@ -42,5 +41,3 @@ if [[ -n $TRAVIS_TAG ]]; then
     git clean -dff
     chartpress --tag $TRAVIS_TAG --push --publish-chart
 fi
-
-cd ..


### PR DESCRIPTION
Add support for running `chartpress --reset` as a git pre-commit hook using the [`pre-commit`](https://pre-commit.com) package. 

To try it out: 

```bash
pipenv install --deploy 
pipenv run pre-commit install
pipenv run pre-commit run chartpress
```

Trying to commit a modified chart value that is handled by `chartpress` results in

```bash
git commit -am 'commiting woop'
black................................................(no files to check)Skipped
Flake8...............................................(no files to check)Skipped
chartpress reset.........................................................Failed
hookid: chartpress

Files were modified by this hook. Additional output:

$> git log -n 1 --pretty=format:%h -- . . jupyterhub singleuser
$> git log -n 1 --pretty=format:%h -- . chartpress.yaml
$> git log -n 1 --pretty=format:%h -- jupyterhub jupyterhub chartpress.yaml
$> git log -n 1 --pretty=format:%h -- git-clone git-clone chartpress.yaml
Updating helm-chart/renku-notebooks/values.yaml: image: {'repository': 'renku/renku-notebooks', 'tag': 'latest'}
Updating helm-chart/renku-notebooks/values.yaml: jupyterhub.hub.image: {'repository': 'renku/jupyterhub-k8s', 'tag': 'latest'}
Updating helm-chart/renku-notebooks/values.yaml: git_clone.image: {'repository': 'renku/git-clone', 'tag': 'latest'}
```