### PR TITLE
feat: spawn new server for different branch

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -79,6 +79,7 @@ def notebook_status(user, namespace, project, commit_sha, notebook=None):
 @authenticated
 def launch_notebook(user, namespace, project, commit_sha, notebook=None):
     """Launch user server with a given name."""
+    branch = request.args.get("branch", "master")
     # 0. check if server already exists and if so return it
     name = server_name(namespace, project, commit_sha)
     server = get_user_server(user, namespace, project, commit_sha)
@@ -124,7 +125,7 @@ def launch_notebook(user, namespace, project, commit_sha, notebook=None):
         )
 
     payload = {
-        "branch": request.args.get("branch", "master"),
+        "branch": branch,
         "commit_sha": commit_sha,
         "namespace": namespace,
         "notebook": notebook,

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -16,14 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for Notebook Services API"""
+from hashlib import md5
+
 import pytest
-
 from gitlab import DEVELOPER_ACCESS
-
 
 AUTHORIZED_HEADERS = {"Authorization": "token 8f7e09b3bf6b8a20"}
 PROJECT_URL = "dummynamespace/dummyproject/0123456789"
-SERVER_NAME = "dummynames-dummyproje-0123456"
+SERVER_NAME = md5((PROJECT_URL.replace("/", "") + "master").encode()).hexdigest()[:16]
 NON_DEVELOPER_ACCESS = DEVELOPER_ACCESS - 1
 
 


### PR DESCRIPTION
Instead of putting the project name and commit sha into the server name, we form the servername by hashing the string 

```
{namespace}{project}{commit-sha}{ref}
```

where `ref` for the time being is assumed to be a branch but could be a tag, for instance.

The resulting pod name is something like `jupyter-rokroskar-9ecaa0eeed735403` (16-digit hash) and the server name is just the hash, i.e. in this case `rokroskar/9ecaa0eeed735403`. 

---

closes #90