### PR TITLE
177 use k8s api for queries

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 ignore = E203, W503

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,7 @@ To run tests:
 To generate HTML coverage report:
 
 .. code-block:: console
+
     pipenv run pytest --cov=renku_notebooks --cov-report html
 
 Test coverage report will be generated in a ``htmlcov`` directory in the project's

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -17,16 +17,17 @@
 # limitations under the License.
 """Implement integration for using GitLab repositories."""
 
-from kubespawner import KubeSpawner
-from kubernetes import client
+import escapism
 import hashlib
 import os
 import string
 import time
-from urllib.parse import urlsplit, urlunsplit
 
-import escapism
+from urllib.parse import urlsplit, urlunsplit
 from tornado import gen, web
+from kubespawner import KubeSpawner
+from kubernetes import client
+
 
 RENKU_ANNOTATION_PREFIX = 'renku.io/'
 """The prefix for renku-specific pod annotations."""
@@ -253,6 +254,12 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
                 options.get('branch'),
             RENKU_ANNOTATION_PREFIX + 'commit-sha':
                 options.get('commit_sha')
+        }
+
+        # add username to labels
+        safe_username = escapism.escape(self.user.name, escape_char='-').lower()
+        self.extra_labels = {
+            RENKU_ANNOTATION_PREFIX + 'username': safe_username
         }
 
         self.delete_grace_period = 30

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -17,17 +17,17 @@
 # limitations under the License.
 """Implement integration for using GitLab repositories."""
 
-import escapism
 import hashlib
 import os
 import string
 import time
-
 from urllib.parse import urlsplit, urlunsplit
-from tornado import gen, web
-from kubespawner import KubeSpawner
-from kubernetes import client
 
+import escapism
+from kubernetes import client
+from tornado import gen, web
+
+from kubespawner import KubeSpawner
 
 RENKU_ANNOTATION_PREFIX = 'renku.io/'
 """The prefix for renku-specific pod annotations."""

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 """Implement integration for using GitLab repositories."""
 
+from kubespawner import KubeSpawner
+from kubernetes import client
 import hashlib
 import os
 import string
@@ -28,6 +30,7 @@ from tornado import gen, web
 
 RENKU_ANNOTATION_PREFIX = 'renku.io/'
 """The prefix for renku-specific pod annotations."""
+
 
 class SpawnerMixin():
     """Extend spawner methods."""
@@ -142,9 +145,6 @@ class SpawnerMixin():
         return result
 
 
-from kubernetes import client
-from kubespawner import KubeSpawner
-
 class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
     """A class for spawning notebooks on Renku-JupyterHub using K8S."""
 
@@ -154,21 +154,21 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         repository = yield self.git_repository()
         options = self.user_options
 
-        ## Process the requested server options
+        # Process the requested server options
         server_options = options.get('server_options', {})
         self.default_url = server_options.get('defaultUrl')
         self.cpu_guarantee = float(server_options.get('cpu_request', 0.1))
 
-        # Make the user pods be in Guaranteed QoS class if the user 
+        # Make the user pods be in Guaranteed QoS class if the user
         # had specified a memory request. Otherwise use a sensible default.
         self.mem_guarantee = server_options.get('mem_request', '500M')
-        self.mem_limit = server_options.get('mem_request','1G')
+        self.mem_limit = server_options.get('mem_request', '1G')
 
         gpu = server_options.get('gpu_request', {})
         if gpu:
             self.extra_resource_limits = {"nvidia.com/gpu": str(gpu)}
 
-        ## Configure the git repository volume
+        # Configure the git repository volume
         git_volume_name = self.pod_name[:54] + '-git-repo'
 
         # 1. Define a new empty volume.
@@ -227,7 +227,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         self.volume_mounts.append(volume_mount)
 
         # 5. Configure autosaving script execution hook
-        self.lifecycle_hooks={
+        self.lifecycle_hooks = {
             "preStop": {
                 "exec": {
                     "command": ["/bin/sh", "-c", "/usr/local/bin/pre-stop.sh", "||", "true"]
@@ -235,7 +235,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             }
         }
 
-        ## Finalize the pod configuration
+        # Finalize the pod configuration
 
         # Set the repository path to the working directory
         self.working_dir = mount_path
@@ -279,7 +279,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         Override the _expand_user_properties from KubeSpawner.
 
         In addition to also escaping the server name, we trim the individual
-        parts of the template to ensure < 63 charactr pod names.
+        parts of the template to ensure < 63 character pod names.
 
         Code adapted from
         https://github.com/jupyterhub/kubespawner/blob/master/kubespawner/spawner.py

--- a/renku_notebooks/api/auth.py
+++ b/renku_notebooks/api/auth.py
@@ -34,7 +34,7 @@ from flask import (
 from jupyterhub.services.auth import HubOAuth
 
 from .. import config
-from ..util.kubernetes_ import annotate_servers
+from ..util.kubernetes_ import get_user_servers
 
 auth = HubOAuth(
     api_token=os.environ.get("JUPYTERHUB_API_TOKEN", "token"), cache_max_age=60
@@ -125,5 +125,5 @@ def get_user_info(user):
             headers=headers,
         ).text
     )
-    annotate_servers(info["servers"])
+    info["servers"] = get_user_servers(user)
     return info

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -28,9 +28,13 @@ from ..util.gitlab_ import (
     get_project,
     check_user_has_developer_permission,
 )
-from ..util.jupyterhub_ import get_user_server, make_server_name
-from ..util.kubernetes_ import annotate_servers, read_namespaced_pod_log
-from .auth import auth, authenticated, get_user_info
+from ..util.jupyterhub_ import make_server_name
+from ..util.kubernetes_ import (
+    read_namespaced_pod_log,
+    get_user_server,
+    get_user_servers,
+)
+from .auth import auth, authenticated
 
 bp = Blueprint("notebooks_blueprint", __name__, url_prefix=config.SERVICE_PREFIX)
 
@@ -41,7 +45,7 @@ SERVER_STATUS_MAP = {"spawn": "spawning", "stop": "stopping"}
 @authenticated
 def user_servers(user):
     """Return a JSON of running servers for the user."""
-    servers = annotate_servers(get_user_info(user).get("servers", {}))
+    servers = get_user_servers(user)
     return jsonify({"servers": servers})
 
 
@@ -64,12 +68,12 @@ def server_options(user, namespace, project, commit_sha):
 @authenticated
 def notebook_status(user, namespace, project, commit_sha, notebook=None):
     """Returns the current status of a user named server or redirect to it if running"""
-    name = make_server_name(namespace, project, commit_sha)
+    # name = make_server_name(namespace, project, commit_sha)
 
     server = get_user_server(user, namespace, project, commit_sha)
-    status = SERVER_STATUS_MAP.get(server.get("pending"), "not found")
+    # status = SERVER_STATUS_MAP.get(server.get("pending"), "not found")
 
-    current_app.logger.debug(f"server {name}: {status}")
+    # current_app.logger.debug(f"server {name}: {status}")
 
     return jsonify(server)
 

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -38,8 +38,6 @@ from .auth import auth, authenticated
 
 bp = Blueprint("notebooks_blueprint", __name__, url_prefix=config.SERVICE_PREFIX)
 
-SERVER_STATUS_MAP = {"spawn": "spawning", "stop": "stopping"}
-
 
 @bp.route("servers")
 @authenticated
@@ -68,13 +66,7 @@ def server_options(user, namespace, project, commit_sha):
 @authenticated
 def notebook_status(user, namespace, project, commit_sha, notebook=None):
     """Returns the current status of a user named server or redirect to it if running"""
-    # name = make_server_name(namespace, project, commit_sha)
-
     server = get_user_server(user, namespace, project, commit_sha)
-    # status = SERVER_STATUS_MAP.get(server.get("pending"), "not found")
-
-    # current_app.logger.debug(f"server {name}: {status}")
-
     return jsonify(server)
 
 

--- a/renku_notebooks/config.py
+++ b/renku_notebooks/config.py
@@ -31,6 +31,9 @@ JUPYTERHUB_ANNOTATION_PREFIX = "hub.jupyter.org"
 JUPYTERHUB_API_TOKEN = os.environ.get("JUPYTERHUB_API_TOKEN", "")
 """The service api token."""
 
+JUPYTERHUB_ORIGIN = os.environ.get("JUPYTERHUB_ORIGIN", "")
+"""Origin property of Jupyterhub, typically https://renkudomain.org"""
+
 RENKU_ANNOTATION_PREFIX = "renku.io/"
 """The prefix used for annotations by Renku."""
 

--- a/renku_notebooks/util/jupyterhub_.py
+++ b/renku_notebooks/util/jupyterhub_.py
@@ -20,15 +20,12 @@
 import os
 from hashlib import md5
 from urllib.parse import urljoin
-
-from flask import Blueprint, current_app
+from flask import Blueprint
 
 from .. import config
-from ..api.auth import get_user_info
+
 
 bp = Blueprint("jh_bp", __name__, url_prefix=config.SERVICE_PREFIX)
-
-RENKU_ANNOTATION_PREFIX = config.RENKU_ANNOTATION_PREFIX
 
 
 def make_server_name(namespace, project, commit_sha, ref="master"):
@@ -48,19 +45,3 @@ def notebook_url(user, server_name, notebook=None):
     if notebook:
         notebook_url += "lab/tree/{notebook}".format(notebook=notebook)
     return notebook_url
-
-
-def get_user_server(user, namespace, project, commit_sha):
-    """Fetch the user named server"""
-    user_info = get_user_info(user)
-    servers = user_info.get("servers", {})
-    for server in servers.values():
-        annotations = server.get("annotations", {})
-        if (
-            annotations.get(RENKU_ANNOTATION_PREFIX + "namespace") == namespace
-            and annotations.get(RENKU_ANNOTATION_PREFIX + "projectName") == project
-            and annotations.get(RENKU_ANNOTATION_PREFIX + "commit-sha") == commit_sha
-        ):
-            current_app.logger.debug(server)
-            return server
-    return {}

--- a/renku_notebooks/util/jupyterhub_.py
+++ b/renku_notebooks/util/jupyterhub_.py
@@ -31,7 +31,7 @@ bp = Blueprint("jh_bp", __name__, url_prefix=config.SERVICE_PREFIX)
 RENKU_ANNOTATION_PREFIX = config.RENKU_ANNOTATION_PREFIX
 
 
-def server_name(namespace, project, commit_sha, ref="master"):
+def make_server_name(namespace, project, commit_sha, ref="master"):
     """Form a DNS-safe server name."""
     server_string = "{namespace}{project}{commit_sha}{ref}".format(
         namespace=namespace, project=project, commit_sha=commit_sha, ref=ref

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -111,10 +111,12 @@ def get_user_servers(user):
         return {"step": c.type, "message": c.message, "reason": c.reason}
 
     def get_pod_status(pod):
-        status = {
-            "phase": pod.status.phase,
-            "ready": pod.status.container_statuses[0].ready,
-        }
+        try:
+            ready = pod.status.container_statuses[0].ready
+        except Exception:
+            ready = False
+
+        status = {"phase": pod.status.phase, "ready": ready}
         conditions_summary = summarise_pod_conditions(pod.status.conditions)
         status.update(conditions_summary)
         return status

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -19,8 +19,8 @@
 import escapism
 import os
 import warnings
-from pathlib import Path
 
+from pathlib import Path
 from flask import current_app
 from kubernetes import client
 from kubernetes.config.config_exception import ConfigException
@@ -145,23 +145,6 @@ def _get_pods():
         kubernetes_namespace, label_selector="heritage = jupyterhub"
     )
     return pods
-
-
-def annotate_servers(servers):
-    """Get servers with renku annotations."""
-    pods = _get_pods().items
-    annotations = {pod.metadata.name: pod.metadata.annotations for pod in pods}
-
-    for server_name, properties in servers.items():
-        pod_annotations = annotations.get(
-            properties.get("state", {}).get("pod_name", ""), {}
-        )
-        servers[server_name]["annotations"] = {
-            key: value
-            for (key, value) in pod_annotations.items()
-            if key.startswith(current_app.config.get("RENKU_ANNOTATION_PREFIX"))
-        }
-    return servers
 
 
 def read_namespaced_pod_log(pod_name, kubernetes_namespace):

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -21,7 +21,7 @@ import warnings
 from pathlib import Path
 
 from flask import current_app
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.config.config_exception import ConfigException
 from kubernetes.config.incluster_config import (
     SERVICE_CERT_FILENAME,
@@ -50,7 +50,7 @@ except ConfigException:
 try:
     with open(namespace_path, "rt") as f:
         kubernetes_namespace = f.read()
-except (config.ConfigException, FileNotFoundError):
+except FileNotFoundError:
     kubernetes_namespace = ""
     warnings.warn(
         "No k8s service account found - not running inside a kubernetes cluster?"

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Kubernetes helper functions."""
+import escapism
 import os
 import warnings
 from pathlib import Path
@@ -28,6 +29,10 @@ from kubernetes.config.incluster_config import (
     SERVICE_TOKEN_FILENAME,
     InClusterConfigLoader,
 )
+from datetime import timezone
+
+from .. import config
+
 
 # adjust k8s service account paths if running inside telepresence
 tele_root = Path(os.getenv("TELEPRESENCE_ROOT", "/"))
@@ -55,6 +60,83 @@ except FileNotFoundError:
     warnings.warn(
         "No k8s service account found - not running inside a kubernetes cluster?"
     )
+
+
+def get_user_server(user, namespace, project, commit_sha):
+    """Fetch the user named server"""
+    RENKU_ANNOTATION_PREFIX = config.RENKU_ANNOTATION_PREFIX
+    servers = get_user_servers(user)
+    for server in servers:
+        annotations = server["annotations"]
+        if (
+            annotations.get(RENKU_ANNOTATION_PREFIX + "namespace") == namespace
+            and annotations.get(RENKU_ANNOTATION_PREFIX + "projectName") == project
+            and annotations.get(RENKU_ANNOTATION_PREFIX + "commit-sha") == commit_sha
+        ):
+            current_app.logger.debug(server)
+            return server
+    return {}
+
+
+def get_user_servers(user):
+    def isoformat(dt):
+        """
+        Render a datetime object as an ISO 8601 UTC timestamp.
+        Naïve datetime objects are assumed to be UTC
+        """
+        if dt is None:
+            return None
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt.isoformat(timespec="microseconds") + "Z"
+
+    pods = _get_user_server_pods(user)
+    servers = {
+        pod.metadata.annotations["hub.jupyter.org/servername"]: {
+            "annotations": pod.metadata.annotations,
+            "name": pod.metadata.annotations["hub.jupyter.org/servername"],
+            "state": {"pod_name": pod.metadata.name},
+            "started": isoformat(pod.status.start_time),
+            "ready": pod.status.container_statuses[0].ready,
+            "status": {
+                "phase": pod.status.phase,
+                "conditions": [
+                    {
+                        "type": c.type,
+                        "status": c.status,
+                        "message": c.message,
+                        "reason": c.reason,
+                        "last_transition_time": isoformat(c.last_transition_time),
+                    }
+                    for c in pod.status.conditions
+                ],
+            },
+        }
+        for pod in pods
+    }
+    return servers
+
+    """
+    These fields are missing from the current implementation
+
+    {
+      'dummynames-dummyproje-0123456': {
+        'last_activity': '2019-06-12T12:53:37.532469Z',
+        'pending': None,
+        'progress_url':
+        '/hub/api/users/dummyuser/servers/dummynames-dummyproje-0123456/progress',
+        'url': '/user/dummyuser/dummynames-dummyproje-0123456/'
+      }
+    }
+    """
+
+
+def _get_user_server_pods(user):
+    safe_username = escapism.escape(user["name"], escape_char="-").lower()
+    pods = v1.list_namespaced_pod(
+        kubernetes_namespace,
+        label_selector=f"heritage=jupyterhub,renku.io/username={safe_username}",
+    )
+    return pods.items
 
 
 def _get_pods():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import time
 
+from datetime import datetime
 from gitlab import DEVELOPER_ACCESS
 
 
@@ -213,11 +214,48 @@ def kubernetes_client(mocker):
                     "metadata": {
                         "name": "dummy-pod-name",
                         "annotations": {
+                            "hub.jupyter.org/servername": "14399552b42bb5ff",
+                            "hub.jupyter.org/username": "dummyuser",
                             "renku.io/namespace": "dummynamespace",
                             "renku.io/projectName": "dummyproject",
                             "renku.io/commit-sha": "0123456789",
                         },
-                    }
+                    },
+                    "status": {
+                        "start_time": datetime(2019, 6, 17, 6, 31, 10),
+                        "phase": "Running",
+                        "container_statuses": [{"ready": True}],
+                        "conditions": [
+                            {
+                                "last_transition_time": "2019-06-17T06:31:19.000000Z",
+                                "message": None,
+                                "reason": None,
+                                "status": "True",
+                                "type": "Initialized",
+                            },
+                            {
+                                "last_transition_time": "2019-06-17T06:31:20.000000Z",
+                                "message": None,
+                                "reason": None,
+                                "status": "True",
+                                "type": "Ready",
+                            },
+                            {
+                                "last_transition_time": "2019-06-17T06:31:20.000000Z",
+                                "message": None,
+                                "reason": None,
+                                "status": "True",
+                                "type": "ContainersReady",
+                            },
+                            {
+                                "last_transition_time": "2019-06-17T06:31:10.000000Z",
+                                "message": None,
+                                "reason": None,
+                                "status": "True",
+                                "type": "PodScheduled",
+                            },
+                        ],
+                    },
                 }
             ]
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,14 @@ def kubernetes_client(mocker):
                             "renku.io/projectName": "dummyproject",
                             "renku.io/commit-sha": "0123456789",
                         },
+                        "labels": {
+                            "app": "jupyterhub",
+                            "chart": "jupyterhub-0.9-e120fda",
+                            "component": "singleuser-server",
+                            "heritage": "jupyterhub",
+                            "release": "dummy-renku",
+                            "renku.io/username": "dummyuser",
+                        },
                     },
                     "status": {
                         "start_time": datetime(2019, 6, 17, 6, 31, 10),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -33,7 +33,7 @@ def test_can_get_user_info(client):
 @pytest.mark.parametrize(
     "headers", [UNAUTHORIZED_HEADERS.copy(), HEADERS_WITHOUT_AUTHORIZATION.copy()]
 )
-def test_unathorized_access_with_json_mime_type_returns_401(headers, client):
+def test_unauthorized_access_with_json_mime_type_returns_401(headers, client):
     headers.update({"Accept": "application/json"})
     response = client.get("/service/user", headers=headers)
     assert response.status_code == 401
@@ -42,7 +42,7 @@ def test_unathorized_access_with_json_mime_type_returns_401(headers, client):
 @pytest.mark.parametrize(
     "headers", [UNAUTHORIZED_HEADERS.copy(), HEADERS_WITHOUT_AUTHORIZATION.copy()]
 )
-def test_unathorized_access_with_non_json_mime_type_returns_302(headers, client):
+def test_unauthorized_access_with_non_json_mime_type_returns_302(headers, client):
     headers = UNAUTHORIZED_HEADERS.copy()
     headers.update({"Accept": "text/html"})
     response = client.get("/service/user", headers=headers)

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -37,7 +37,7 @@ def test_can_create_notebooks(client):
     assert response.status_code == 200 or response.status_code == 201
 
 
-def test_can_get_created_notebooks(client):
+def test_can_get_created_notebooks(client, kubernetes_client):
     client.post(f"/service/{PROJECT_URL}", headers=AUTHORIZED_HEADERS)
 
     response = client.get("/service/servers", headers=AUTHORIZED_HEADERS)
@@ -108,7 +108,7 @@ def test_users_with_no_developer_access_cannot_create_notebooks(client, gitlab):
     assert response.status_code == 401
 
 
-def test_getting_logs_for_nonexisting_notebook_returns_404(client, kubernetes_client):
+def test_getting_logs_for_nonexisting_notebook_returns_404(client):
     response = client.get(
         f"/service/{PROJECT_URL}/logs",
         headers=AUTHORIZED_HEADERS,


### PR DESCRIPTION
Uses Kubernetes API to get information about running servers instead of using JupyterHub's. This should remove the load from the JupyterHub and increase the number of concurrent servers.

The JSON response from the `/servers` endpoint has changed because we don't have some information that used to come fro the JupyterHub.

This also include some code from the https://github.com/SwissDataScienceCenter/renku-notebooks/pull/181 PR so that one can be closed without merging.

---

closes #181 