### PR TITLE
187 recover from autosave only when branch commit match

### DIFF
--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -24,7 +24,7 @@ GIT_FETCH_OUT=`git fetch && git branch -a`
 IFS=$'\n' ALL_BRANCHES=($GIT_FETCH_OUT)
 for branch in "${ALL_BRANCHES[@]}"
 do
-    if [[ $branch == *"${REMOTES_ORIGIN}${AUTOSAVE_BRANCH_PREFIX}"* ]] ; then
+    if [[ $branch == *"${REMOTES_ORIGIN}${AUTOSAVE_BRANCH_PREFIX}/${BRANCH}/${COMMIT_SHA}"* ]] ; then
         AUTOSAVE_REMOTE_BRANCH=${branch// /}
     fi
 done

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -211,6 +211,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
                 ),
                 client.V1EnvVar(
                     name='BRANCH', value=options.get('branch', 'master')
+                ),
+                client.V1EnvVar(
+                    name='JUPYTERHUB_USER', value=self.user.name
                 )
             ],
             image=options.get('git_clone_image'),

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -123,7 +123,7 @@ def get_user_servers(user):
     def get_pod_status(pod):
         try:
             ready = pod.status.container_statuses[0].ready
-        except IndexError:
+        except (IndexError, TypeError):
             ready = False
 
         status = {"phase": pod.status.phase, "ready": ready}


### PR DESCRIPTION
The autosave branch is recovered only when its `branch` and `commit-sha` match with the those of notebook's. See https://github.com/SwissDataScienceCenter/renku-notebooks/issues/187.

This also fixes an uncaught exception which was introduced in https://github.com/SwissDataScienceCenter/renku-notebooks/pull/185.

This was tested on a repo with two branches for various scenarios.