### PR TITLE
fix: use shortened commit-sha to check for an autosave match

### DIFF
--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -24,7 +24,7 @@ GIT_FETCH_OUT=`git fetch && git branch -a`
 IFS=$'\n' ALL_BRANCHES=($GIT_FETCH_OUT)
 for branch in "${ALL_BRANCHES[@]}"
 do
-    if [[ $branch == *"${REMOTES_ORIGIN}${AUTOSAVE_BRANCH_PREFIX}/${BRANCH}/${COMMIT_SHA}"* ]] ; then
+    if [[ $branch == *"${REMOTES_ORIGIN}${AUTOSAVE_BRANCH_PREFIX}/${BRANCH}/${COMMIT_SHA:0:7}"* ]] ; then
         AUTOSAVE_REMOTE_BRANCH=${branch// /}
     fi
 done

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -49,12 +49,12 @@ PRE_SAVE_BRANCH_NAME=${AUTOSAVE_REMOTE_BRANCH_ITEMS[5]}
 (git checkout ${PRE_SAVE_BRANCH_NAME} || git checkout -b ${PRE_SAVE_BRANCH_NAME})
 git submodule init && git submodule update
 
-PRE_SAVE_COMMIT_ID=${AUTOSAVE_REMOTE_BRANCH_ITEMS[6]}
-git reset --hard $PRE_SAVE_COMMIT_ID
+PRE_SAVE_LOCAL_COMMIT_SHA=${AUTOSAVE_REMOTE_BRANCH_ITEMS[7]}
+git reset --hard $PRE_SAVE_LOCAL_COMMIT_SHA
 
 AUTOSAVE_BRANCH=${AUTOSAVE_REMOTE_BRANCH/$REMOTES_ORIGIN/''}
 git pull --rebase origin $AUTOSAVE_BRANCH
-git reset --soft $PRE_SAVE_COMMIT_ID
+git reset --soft $PRE_SAVE_LOCAL_COMMIT_SHA
 git reset HEAD .
 git push origin :"$AUTOSAVE_BRANCH"
 

--- a/helm-chart/renku-notebooks/templates/configmap.yaml
+++ b/helm-chart/renku-notebooks/templates/configmap.yaml
@@ -46,7 +46,12 @@ data:
     fi
 
     CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-    CURRENT_SHA=`git rev-parse --short HEAD`
+    CURRENT_SHA=`git rev-parse --short @{upstream}`
+
+    if [ -z "$CURRENT_SHA" ]; then
+      CURRENT_SHA=`git rev-parse --short HEAD`
+    fi
+
     AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${CURRENT_SHA}"
     git checkout -b "$AUTOSAVE_BRANCH"
     git add .

--- a/helm-chart/renku-notebooks/templates/configmap.yaml
+++ b/helm-chart/renku-notebooks/templates/configmap.yaml
@@ -46,16 +46,17 @@ data:
     fi
 
     CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-    CURRENT_SHA=`git rev-parse --short @{upstream}`
+    LOCAL_SHA=`git rev-parse --short HEAD`
+    REMOTE_SHA=`git rev-parse --short @{upstream}`
 
-    if [ -z "$CURRENT_SHA" ]; then
-      CURRENT_SHA=`git rev-parse --short HEAD`
+    if [ -z "$REMOTE_SHA" ]; then
+      REMOTE_SHA="${LOCAL_SHA}"
     fi
 
-    AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${CURRENT_SHA}"
+    AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${REMOTE_SHA}/${LOCAL_SHA}"
     git checkout -b "$AUTOSAVE_BRANCH"
     git add .
-    git commit -am "Auto-saving for $JUPYTERHUB_USER on branch $CURRENT_BRANCH and commit $CURRENT_SHA"
+    git commit -am "Auto-saving for $JUPYTERHUB_USER on branch $CURRENT_BRANCH and commit $LOCAL_SHA"
     git push origin "$AUTOSAVE_BRANCH"
     git checkout master
     git branch -D "$AUTOSAVE_BRANCH"

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -111,6 +111,9 @@ def get_user_servers(user):
             }
             return sorted(conditions, key=lambda c: CONDITIONS_ORDER[c.type])
 
+        if not conditions:
+            return {"step": None, "message": None, "reason": None}
+
         for c in sort_conditions(conditions):
             if (
                 (c.type == "Unschedulable" and c.status == "True")


### PR DESCRIPTION
Fixes a bug in check for autosaved branch commit-sha where it was checking against the long commit-sha instead of the short one.