### PR TITLE
150 can force delete pods

### DIFF
--- a/helm-chart/renku-notebooks/templates/role.yaml
+++ b/helm-chart/renku-notebooks/templates/role.yaml
@@ -20,4 +20,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
 {{- end -}}

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -175,9 +175,9 @@ def stop_server(user, server_name):
             else:
                 return make_response("Cannot force delete server", 400)
         return make_response("", 404)
-    else:
-        r = delete_named_server(user, server_name)
-        return current_app.response_class(r.content, status=r.status_code)
+
+    r = delete_named_server(user, server_name)
+    return current_app.response_class(r.content, status=r.status_code)
 
 
 @bp.route("server_options")

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -26,6 +26,7 @@ from urllib.parse import urljoin
 import escapism
 from flask import current_app
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
 from kubernetes.config.incluster_config import (
     SERVICE_CERT_FILENAME,
@@ -91,6 +92,19 @@ def get_user_server(user, server_name):
     """Fetch the user server with specific name"""
     servers = _get_all_user_servers(user)
     return servers.get(server_name, {})
+
+
+def delete_user_pod(user, pod_name):
+    """Delete user's server with specific name"""
+    try:
+        v1.delete_namespaced_pod(
+            pod_name, kubernetes_namespace, grace_period_seconds=30
+        )
+        return True
+    except ApiException as e:
+        msg = f"Cannot delete server: {pod_name} for user: {user}, error: {e}"
+        current_app.logger.error(msg)
+        return False
 
 
 def _get_all_user_servers(user):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,3 +272,9 @@ def kubernetes_client(mocker):
     kubernetes_client_mock.list_namespaced_pod.return_value = namespaced_pods
 
     kubernetes_client_mock.read_namespaced_pod_log.return_value = "some logs"
+
+    def force_delete_pod(*args, **kwargs):
+        empty = _AttributeDictionary({"items": []})
+        kubernetes_client_mock.list_namespaced_pod.return_value = empty
+
+    kubernetes_client_mock.delete_namespaced_pod.side_effect = force_delete_pod

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -92,6 +92,21 @@ def test_can_delete_created_notebooks(client, kubernetes_client):
     assert response.status_code == 204
 
 
+def test_can_force_delete_created_notebooks(client, kubernetes_client):
+    create_notebook_with_default_parameters(client)
+
+    response = client.delete(
+        f"/service/servers/{SERVER_NAME}",
+        query_string={"force": "true"},
+        headers=AUTHORIZED_HEADERS,
+    )
+    assert response.status_code == 204
+
+    response = client.get("/service/servers", headers=AUTHORIZED_HEADERS)
+    assert response.status_code == 200
+    assert response.json.get("servers") == {}
+
+
 def test_recreating_notebooks_return_current_server(client, kubernetes_client):
     create_notebook_with_default_parameters(client)
 


### PR DESCRIPTION
This PR enable to force-delete a pod by bypassing JupyterHub API and using K8s API directly. When a delete request has a `force` parameter which its value is set to `true`, notebook services uses the K8s API directly and kills the pod.
Make sure that you use this method as a last resort (i.e. after trying to DELETE normally).

Closes https://github.com/SwissDataScienceCenter/renku-notebooks/issues/150. 
Addresses https://github.com/SwissDataScienceCenter/renku-ui/issues/361