### PR TITLE
feat: use project name in the notebook URL

### DIFF
--- a/renku_notebooks/util/jupyterhub_.py
+++ b/renku_notebooks/util/jupyterhub_.py
@@ -37,7 +37,7 @@ def make_server_name(namespace, project, branch, commit_sha):
     """Form a 16-digit hash server ID."""
     server_string = f"{namespace}{project}{branch}{commit_sha}"
     return "{project}-{hash}".format(
-        project=project[:46], hash=md5(server_string.encode()).hexdigest()[:16]
+        project=project[:54], hash=md5(server_string.encode()).hexdigest()[:8]
     )
 
 

--- a/renku_notebooks/util/jupyterhub_.py
+++ b/renku_notebooks/util/jupyterhub_.py
@@ -36,7 +36,9 @@ __headers = {auth.auth_header_name: f"token {auth.api_token}"}
 def make_server_name(namespace, project, branch, commit_sha):
     """Form a 16-digit hash server ID."""
     server_string = f"{namespace}{project}{branch}{commit_sha}"
-    return md5(server_string.encode()).hexdigest()[:16]
+    return "{project}-{hash}".format(
+        project=project[:46], hash=md5(server_string.encode()).hexdigest()[:16]
+    )
 
 
 def check_user_has_named_server(user, server_name):

--- a/renku_notebooks/util/jupyterhub_.py
+++ b/renku_notebooks/util/jupyterhub_.py
@@ -20,7 +20,6 @@
 import json
 import os
 from hashlib import md5
-from urllib.parse import urljoin
 
 import requests
 from jupyterhub.services.auth import HubOAuth
@@ -38,17 +37,6 @@ def make_server_name(namespace, project, branch, commit_sha):
     """Form a 16-digit hash server ID."""
     server_string = f"{namespace}{project}{branch}{commit_sha}"
     return md5(server_string.encode()).hexdigest()[:16]
-
-
-def notebook_url(user, server_name, notebook=None):
-    """Form the notebook server URL."""
-    notebook_url = urljoin(
-        os.environ.get("JUPYTERHUB_BASE_URL"),
-        "user/{user[name]}/{server_name}/".format(user=user, server_name=server_name),
-    )
-    if notebook:
-        notebook_url += "lab/tree/{notebook}".format(notebook=notebook)
-    return notebook_url
 
 
 def check_user_has_named_server(user, server_name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,7 +214,7 @@ def kubernetes_client(mocker):
                     "metadata": {
                         "name": "dummy-pod-name",
                         "annotations": {
-                            "hub.jupyter.org/servername": "d2e2d0405876d719",
+                            "hub.jupyter.org/servername": "dummyproject-d2e2d0405876d719",
                             "hub.jupyter.org/username": "dummyuser",
                             "renku.io/namespace": "dummynamespace",
                             "renku.io/projectName": "dummyproject",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,7 +214,7 @@ def kubernetes_client(mocker):
                     "metadata": {
                         "name": "dummy-pod-name",
                         "annotations": {
-                            "hub.jupyter.org/servername": "dummyproject-d2e2d0405876d719",
+                            "hub.jupyter.org/servername": "dummyproject-d2e2d040",
                             "hub.jupyter.org/username": "dummyuser",
                             "renku.io/namespace": "dummynamespace",
                             "renku.io/projectName": "dummyproject",


### PR DESCRIPTION
Server name created by JupyterHub includes up to 46 chars from the reference project name. This is a possible quick solution to SwissDataScienceCenter/renku-ui#584 *apparently* without any significative side effect.

Preview available here: https://lorenzotest.dev.renku.ch

Relevant changes: the server name is different, so the JupyterLab url will also be affected accordingly
Here is the url comparison of a project named `zurich-bikes-tutorial`

![Screenshot from 2019-09-11 16-37-56](https://user-images.githubusercontent.com/43481553/64790117-ddc3d700-d575-11e9-8b18-24ef0154b5b1.png)

fix SwissDataScienceCenter/renku-ui#584