### PR TITLE
fix(jupyterhub): check permissions before adding environment variables

### DIFF
--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -127,10 +127,11 @@ class SpawnerMixin:
 
         self.cmd = "jupyterhub-singleuser"
 
-        environment = {
-            variable.key: variable.value for variable in gl_project.variables.list()
-        }
-        self.environment.update(environment)
+        if access_level >= gitlab.MAINTAINER_ACCESS:
+            environment = {
+                variable.key: variable.value for variable in gl_project.variables.list()
+            }
+            self.environment.update(environment)
 
         result = yield super().start(*args, **kwargs)
         return result


### PR DESCRIPTION
Even if it's not clear why the project's environment variables were included in the spawner code, the feature seems to work according to the `Manage variable` permission of GitLab (https://docs.gitlab.com/ee/user/permissions.html).

Instead of removing the feature or increasing the requirement for starting JupyterLab to `Maintainer` level, it seems reasonable to keep this. The reference issue suggests to gracefully fail for `Developer`, but this PR checks instead for the permission level to decide whether to including the variables or not. It seems a reasonable solution since this appears to be a feature used by advanced users and they should be aware of the GitLab limitations implied by the member permissions.

Preview available at https://lorenzotest.dev.renku.ch

fix #210

P.S. We may also want to add a simple warning message for "non-at-least-maintainer" users in the "Notebooks Servers" tab in the UI to inform them that they may have limitations. This seems reasonable since we already discussed about relaxing the requirements to start notebooks, in which case this message would be even more useful.