### PR TITLE
chore: move comment to avoid chartpress problem

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -171,7 +171,8 @@ jupyterhub:
       clientId: jupyterhub
       ## use openssl rand -hex 32 to generate clientSecret
       clientSecret:
-      callbackUrl: # Leaving it null forces the default callback url
+      # Leaving it null forces the default callback url
+      callbackUrl:
   proxy:
     service:
       type: ClusterIP


### PR DESCRIPTION
This *apparently* useless PR addresses a silly issue I experience with `chartpress`.
In short: every time I run `chartpress` it duplicates/moves data for the `callbackUrl` value (see screen below). I guess it doesn't like a comment next to an empty value :man_shrugging: 

![Screenshot from 2019-09-17 16-08-35](https://user-images.githubusercontent.com/43481553/65050501-c31fa280-d967-11e9-8e16-678a8c90665c.png)

