### PR TITLE
feat: gracefully handle predictable k8s api errors when querying for logs

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -216,15 +216,15 @@ def server_options(user):
 
 @bp.route("logs/<server_name>")
 @authenticated
-def server_logs(user, server_name):
-    """"Return the logs of the running server."""
+def server_logs(user, server_name, max_log_lines=100):
+    """Return the logs of the running server."""
     if request.environ["HTTP_ACCEPT"] == "application/json":
         return make_response("Only supporting text/plain.", 406)
     server = get_user_server(user, server_name)
     if server:
         pod_name = server.get("state", {}).get("pod_name", "")
         try:
-            logs = read_namespaced_pod_log(pod_name)
+            logs = read_namespaced_pod_log(pod_name, max_log_lines)
         # catch predictable k8s api errors and return a significative string
         except ApiException as e:
             logs = ""

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -18,6 +18,7 @@
 """Notebooks service API."""
 import json
 import os
+from kubernetes.client.rest import ApiException
 
 from flask import Blueprint, abort, current_app, jsonify, request, make_response
 
@@ -225,7 +226,8 @@ def server_logs(user, server_name):
         try:
             logs = read_namespaced_pod_log(pod_name)
         # catch predictable k8s api errors and return a significative string
-        except Exception as e:
+        except ApiException as e:
+            logs = ""
             if hasattr(e, "body"):
                 k8s_error = json.loads(e.body)
                 logs = f"Logs unavailable: {k8s_error['message']}"

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -182,5 +182,14 @@ def _get_all_user_servers(user):
     return servers
 
 
-def read_namespaced_pod_log(pod_name):
-    return v1.read_namespaced_pod_log(pod_name, kubernetes_namespace, tail_lines=100)
+def read_namespaced_pod_log(pod_name, max_log_lines=0):
+    """
+    Read pod's logs.
+    """
+    if max_log_lines == 0:
+        logs = v1.read_namespaced_pod_log(pod_name, kubernetes_namespace)
+    else:
+        logs = v1.read_namespaced_pod_log(
+            pod_name, kubernetes_namespace, tail_lines=max_log_lines
+        )
+    return logs

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -183,4 +183,4 @@ def _get_all_user_servers(user):
 
 
 def read_namespaced_pod_log(pod_name):
-    return v1.read_namespaced_pod_log(pod_name, kubernetes_namespace)
+    return v1.read_namespaced_pod_log(pod_name, kubernetes_namespace, tail_lines=100)


### PR DESCRIPTION
During the spawning phase, querying kubernetes logs API may result in a predictable error. This PR returns a plaintext message instead of a `400` error response