### PR TITLE
fix: reference environment starting commit on autosave branches

### DIFF
--- a/helm-chart/renku-notebooks/templates/configmap.yaml
+++ b/helm-chart/renku-notebooks/templates/configmap.yaml
@@ -47,16 +47,12 @@ data:
 
     CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
     LOCAL_SHA=`git rev-parse --short HEAD`
-    REMOTE_SHA=`git rev-parse --short @{upstream}`
+    INITIAL_SHA="${CI_COMMIT_SHA:0:7}"
 
-    if [ -z "$REMOTE_SHA" ]; then
-      REMOTE_SHA="${LOCAL_SHA}"
-    fi
-
-    AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${REMOTE_SHA}/${LOCAL_SHA}"
+    AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${INITIAL_SHA}/${LOCAL_SHA}"
     git checkout -b "$AUTOSAVE_BRANCH"
     git add .
-    git commit -am "Auto-saving for $JUPYTERHUB_USER on branch $CURRENT_BRANCH and commit $LOCAL_SHA"
+    git commit -am "Auto-saving for $JUPYTERHUB_USER on branch $CURRENT_BRANCH from commit $INITIAL_SHA"
     git push origin "$AUTOSAVE_BRANCH"
     git checkout master
     git branch -D "$AUTOSAVE_BRANCH"


### PR DESCRIPTION
Use the environment starting commit to compose the autosaved branches.

A preview is available on https://lorenzotest.dev.renku.ch and can easily be tested from the UI

#### How to test
From any project with >= 2 commits (e.g. fork https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/zurich-bikes-tutorial/environments) start a new environment from an old commit, do any work (e.g. `touch aaa`) and stop the notebook without further actions. Trying to start a new environment from the same commit will result in the autosave message, while trying to start from the latest commit won't display any message. The behavior is currently inverted on https://dev.renku.ch/

fix #219