### PR TITLE
fix: check lfs setting as a string

### DIFF
--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 rm -rf ${MOUNT_PATH}/*
 (rm -rf ${MOUNT_PATH}/.* || true)
-git config push.default simple
+git config --system push.default simple
 git lfs install $LFS_SKIP_SMUDGE --system
 git clone $REPOSITORY ${MOUNT_PATH}
 git lfs install $LFS_SKIP_SMUDGE --local

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -5,7 +5,7 @@
 # the proper file permissions.
 set -x
 
-if [ "$LFS_AUTO_FETCH" == "True" ]; then
+if [ "$LFS_AUTO_FETCH" = 1 ]; then
   LFS_SKIP_SMUDGE="";
 else
   LFS_SKIP_SMUDGE="--skip-smudge";

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -5,8 +5,10 @@
 # the proper file permissions.
 set -x
 
-if [ "$LFS_AUTO_FETCH" = 1 ]; then LFS_SKIP_SMUDGE="";
-else LFS_SKIP_SMUDGE="--skip-smudge";
+if [ "$LFS_AUTO_FETCH" == "True" ]; then
+  LFS_SKIP_SMUDGE="";
+else
+  LFS_SKIP_SMUDGE="--skip-smudge";
 fi
 
 rm -rf ${MOUNT_PATH}/*

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -186,14 +186,14 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             for container in self.init_containers
             if not container.name.startswith(init_container_name)
         ]
+        lfs_auto_fetch = server_options.get("lfs_auto_fetch")
         init_container = client.V1Container(
             name=init_container_name,
             env=[
                 client.V1EnvVar(name="MOUNT_PATH", value=mount_path),
                 client.V1EnvVar(name="REPOSITORY", value=repository),
                 client.V1EnvVar(
-                    name="LFS_AUTO_FETCH",
-                    value=str(server_options.get("lfs_auto_fetch")),
+                    name="LFS_AUTO_FETCH", value="1" if lfs_auto_fetch else "0",
                 ),
                 client.V1EnvVar(
                     name="COMMIT_SHA", value=str(options.get("commit_sha"))


### PR DESCRIPTION
The environment variable `LFS_AUTO_FETCH` is set to the string `"True"` when the lfs fetch checkbox is ticked: this is why the condition was always testing false when checking for `= 1`, therefore ignoring the setting.

I am not sure if this changed recently or if it simply didn't work in the past. Maybe we could fix this by making `LFS_AUTO_FETCH = true` (or `1`) instead of testing for `== "True"`

fix #227

***TESTING***
Preview available here: https://lorenzotest.dev.renku.ch/
* try to start notebooks on a project with lfs files, once with and once without selecting the lfs fetch checkbox
* verify with `git lfs ls-files` that lfs files are available

