### PR TITLE
feat: add requested resources info to servers endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,6 +265,15 @@ def kubernetes_client(mocker):
                             },
                         ],
                     },
+                    "spec": {
+                        "containers": [
+                            {
+                                "resources": {
+                                    "requests": {"cpu": "500m", "memory": "2147483648"}
+                                }
+                            }
+                        ]
+                    },
                 }
             ]
         }


### PR DESCRIPTION
Add the requested resources info to the `GET /servers` API response. This is an example, the new part is in the attribute `resources`

```
{
  "servers": {
    "flights-tutorial-d991bad2": {
      "annotations": {
        [...]
      },
      "name": "flights-tutorial-d991bad2",
      "resources": {
        "cpu": "0.1",
        "memory": "1073741824"
      },
      "started": "2020-03-12T16:54:30.000000Z",
      "state": {
        "pod_name": "jupyter-lorenzo-2ecavazzi-2etech-flights-2dtutorial-2dd991bad2"
      },
      "status": {
        [...]
      },
      "url": "https://lorenzo.dev.renku.ch/jupyterhub/user/lorenzo.cavazzi.tech/flights-tutorial-d991bad2/"
    }
  }
}
```

UPDATE: It's possible to test the change in `lorenzotest` deplyoment: https://lorenzotest.dev.renku.ch/

fix #223