### PR TITLE
feat: add repository url to annoations

### DIFF
--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -238,6 +238,13 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         self.notebook_dir = mount_path
 
         # add git project-specific annotations
+        repository_url = (
+            os.environ.get("GITLAB_URL", "http://gitlab.renku.build")
+            + "/"
+            + options.get("namespace")
+            + "/"
+            + options.get("project")
+        )
         self.extra_annotations = {
             RENKU_ANNOTATION_PREFIX + "namespace": options.get("namespace"),
             RENKU_ANNOTATION_PREFIX + "projectName": options.get("project"),
@@ -245,6 +252,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             + "projectId": "{}".format(options.get("project_id")),
             RENKU_ANNOTATION_PREFIX + "branch": options.get("branch"),
             RENKU_ANNOTATION_PREFIX + "commit-sha": options.get("commit_sha"),
+            RENKU_ANNOTATION_PREFIX + "repository": repository_url,
         }
 
         # add username to labels

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,9 @@ def kubernetes_client(mocker):
                             "renku.io/namespace": "dummynamespace",
                             "renku.io/projectName": "dummyproject",
                             "renku.io/commit-sha": "0123456789",
+                            "renku.io/repository": (
+                                "https://fakegitlab.renku.ch/dummynamespace/dummyproject"
+                            ),
                         },
                         "labels": {
                             "app": "jupyterhub",


### PR DESCRIPTION
Add the repository link to the pod's annotations and return it when querying the `GET /servers` endpoint.

```
"annotations": {
        "cni.projectcalico.org/podIP": "10.42.5.38/32",
        "hub.jupyter.org/servername": "flights-tutorial-d991bad2",
        "hub.jupyter.org/username": "lorenzo.cavazzi.tech",
        "renku.io/branch": "master",
        "renku.io/commit-sha": "c581b56edc53b18df6d352241590d6be1a1cf51e",
        "renku.io/namespace": "lorenzo.cavazzi.tech",
        "renku.io/projectId": "1228",
        "renku.io/projectName": "flights-tutorial",
        "renku.io/repository": "https://dev.renku.ch/gitlab/lorenzo.cavazzi.tech/flights-tutorial"
},
```

Needed by SwissDataScienceCenter/renku-ui#493