### PR TITLE
feat: contrain the container gids

### DIFF
--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -261,6 +261,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
 
         self.delete_grace_period = 30
 
+        self.gid = 100
+        self.supplemental_gids = [1000]
+
         pod = yield super().get_pod_manifest()
 
         # Because repository comes from a coroutine, we can't put it simply in `get_env()`


### PR DESCRIPTION
This PR constrains the gids used for the container processes. It's currently running on rok.dev.renku.ch. 

With this PR, the notebook container runs as gid 100 and sets the user to be a member of groups 100 and 1000. 