### PR TITLE
feat: allow unprivileged and anonymous users to launch servers

### DIFF
--- a/helm-chart/make-values-tmp.py
+++ b/helm-chart/make-values-tmp.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import argparse
+import secrets
+import sys
+
+import ruamel.yaml
+
+yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
+
+# Note: We hardcode "notebooks.fullname" / the service
+# name here. These secondary deployments MUST run in their
+# own dedicated namespace anyway.
+TEMPORARY_NOTEBOOKS_SERVICE_NAME = "notebooks-tmp"
+
+
+def main():
+    """Create a values file for a secondary notebooks service helm deployment
+    (inluding a secondary Jupyterhub) which handles temporary sessions for
+    logged-out users."""
+
+    argparser = argparse.ArgumentParser(description=main.__doc__)
+
+    argparser.add_argument("--values-file", help="Input values file", required=True)
+    argparser.add_argument(
+        "--renku-namespace", help="Namespace for the Renku deployment", required=True
+    )
+    argparser.add_argument(
+        "--output", "-o", help="Output file", default="notebooks-tmp-values.yaml"
+    )
+    args = argparser.parse_args()
+
+    with open(args.values_file) as f:
+        values = yaml.load(f.read())
+
+    # Copy over all the necessary stuff from the original values file
+    new_values = values["notebooks"]
+
+    # We don't know the release name here, so we override the name of the service
+
+    new_values["fullnameOverride"] = TEMPORARY_NOTEBOOKS_SERVICE_NAME
+
+    new_values["global"] = {
+        "renku": {"domain": values["global"]["renku"]["domain"]},
+        "useHTTPS": values["global"]["useHTTPS"],
+    }
+
+    hub_section = new_values["jupyterhub"]["hub"]
+    hub_section["cookie_secret"] = secrets.token_hex(32)
+    hub_section["baseUrl"] = "{}-tmp/".format(hub_section["baseUrl"].rstrip("/"))
+    hub_section["db"]["url"] = (
+        hub_section["db"]["url"]
+        .replace("jupyterhub", "jupyterhub-tmp")
+        .replace("postgresql:", "postgresql.{}.svc:".format(args.renku_namespace))
+    )
+    hub_section["extraEnv"] = [
+        env
+        for env in hub_section["extraEnv"]
+        if env["name"] not in ["PGPASSWORD", "JUPYTERHUB_AUTHENTICATOR"]
+    ]
+    hub_section["extraEnv"].append(
+        {
+            "name": "PGPASSWORD",
+            "valueFrom": {
+                "secretKeyRef": {
+                    "name": "renku-jupyterhub-tmp-postgres",
+                    "key": "jupyterhub-tmp-postgres-password",
+                }
+            },
+        }
+    )
+    hub_section["extraEnv"].append({"name": "JUPYTERHUB_AUTHENTICATOR", "value": "tmp"})
+    hub_section["services"]["notebooks"]["url"] = "http://{}".format(
+        TEMPORARY_NOTEBOOKS_SERVICE_NAME
+    )
+    hub_section["services"]["notebooks"]["apiToken"] = secrets.token_hex(32)
+    del hub_section["services"]["gateway"]
+
+    auth_section = new_values["jupyterhub"]["auth"]
+    auth_section["state"]["cryptoKey"] = secrets.token_hex(32)
+    auth_section["type"] = "tmp"
+    del auth_section["gitlab"]
+
+    new_values["jupyterhub"]["proxy"]["secretToken"] = secrets.token_hex(32)
+
+    # Add some reasonably short defaults for server culling
+    new_values["jupyterhub"]["cull"] = {
+        "enabled": True,
+        "timeout": 3600,
+        "every": 60,
+    }
+
+    # Configure ingress rule for /jupyterhub-tmp/
+    new_values["ingress"] = values["ingress"]
+    new_values["ingress"]["jupyterhubPath"] = new_values["jupyterhub"]["hub"]["baseUrl"]
+
+    with open(args.output, "w") as f:
+        yaml.dump(new_values, f)
+    sys.stdout.write("Successfully created {}".format(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/helm-chart/renku-notebooks/Chart.yaml
+++ b/helm-chart/renku-notebooks/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Notebooks service
 name: renku-notebooks
-version: 0.7.1
+version: 0.7.2

--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: JUPYTERHUB_AUTHENTICATOR
+              value: {{ .Values.jupyterhub.auth.type | quote }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm-chart/renku-notebooks/templates/ingress.yaml
+++ b/helm-chart/renku-notebooks/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "notebooks.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPath := .Values.ingress.jupyterhubPath -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -31,13 +31,13 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          # - path: {{ $ingressPath }}
+          #   backend:
+          #     serviceName: {{ $fullName }}
+          #     servicePort: http
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-          # - path: /jupyterhub
-          #   backend:
-          #     serviceName: proxy-public
-          #     servicePort: 8000
+              serviceName: proxy-public
+              servicePort: 8000
   {{- end }}
 {{- end }}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -98,9 +98,8 @@ jupyterhub:
       tag: 'latest'
     allowNamedServers: true
     services:
-      gateway:
-        oauth_no_confirm: true
       notebooks:
+        oauth_no_confirm: true
         url: http://renku-notebooks
         admin: true
         oauth_client_id: service-notebooks

--- a/jupyterhub/requirements.txt
+++ b/jupyterhub/requirements.txt
@@ -17,5 +17,6 @@
 # limitations under the License.
 
 jupyterhub-kubespawner==0.11.1
+jupyterhub-tmpauthenticator==0.6
 jupyterhub==1.1.0
 python-gitlab

--- a/renku_notebooks/api/auth.py
+++ b/renku_notebooks/api/auth.py
@@ -62,9 +62,11 @@ def authenticated(f):
                 return response
 
             # redirect to login url on failed auth
-            state = auth.generate_state(next_url=request.path)
+            state = auth.generate_state(next_url=request.url)
             current_app.logger.debug(
-                "Auth flow, redirecting to: {}".format(auth.login_url)
+                "Auth flow, redirecting to {} with next url {}".format(
+                    auth.login_url, request.url
+                )
             )
             response = make_response(redirect(auth.login_url + "&state=%s" % state))
             response.set_cookie(auth.state_cookie_name, state)
@@ -103,3 +105,10 @@ def whoami(user):
     user_info = get_user_info(user)
     user_info["servers"] = get_user_servers(user)
     return jsonify(user_info)
+
+
+@bp.route("login-tmp")
+@authenticated
+def redirect_to_ui(user):
+    """Return information about the authenticated user."""
+    return make_response(redirect(request.args["redirect_url"]))

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -26,7 +26,6 @@ from .. import config
 from ..util.gitlab_ import (
     get_notebook_image,
     get_project,
-    check_user_has_developer_permission,
 )
 from ..util.jupyterhub_ import (
     make_server_name,
@@ -125,13 +124,6 @@ def launch_notebook(user):
         return current_app.response_class(
             status=404,
             response=f"Cannot find project {project} for user: {user['name']}.",
-        )
-
-    # Return 401 if user is not a developer
-    if not check_user_has_developer_permission(user, gl_project):
-        return current_app.response_class(
-            status=401,
-            response="Not authorized to use interactive environments for this project.",
         )
 
     # set the notebook image

--- a/renku_notebooks/config.py
+++ b/renku_notebooks/config.py
@@ -42,3 +42,9 @@ SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 
 SERVICE_PREFIX = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", "/")
 """Service prefix is set by JupyterHub service spawner."""
+
+GITLAB_AUTH = os.environ.get("JUPYTERHUB_AUTHENTICATOR", "gitlab") == "gitlab"
+"""Check if we're authenticating with GitLab (and thus have a GitLab oauth token)."""
+
+JUPYTERHUB_PATH_PREFIX = os.environ.get("JUPYTERHUB_BASE_URL", "/jupyterhub")
+"""Base path under which Jupyterhub is running."""

--- a/renku_notebooks/util/gitlab_.py
+++ b/renku_notebooks/util/gitlab_.py
@@ -30,7 +30,6 @@ def get_project(user, namespace, project):
         config.GITLAB_URL, api_version=4, oauth_token=_get_oauth_token(user)
     )
     try:
-        gl.auth()
         return gl.projects.get("{0}/{1}".format(namespace, project))
     except Exception as e:
         current_app.logger.error(
@@ -41,6 +40,9 @@ def get_project(user, namespace, project):
 def _get_oauth_token(user):
     """Retrieve the user's GitLab token from the oauth metadata."""
     from ..api.auth import get_user_info
+
+    if not config.GITLAB_AUTH:
+        return None
 
     auth_state = get_user_info(user).get("auth_state", None)
     return None if not auth_state else auth_state.get("access_token")

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -177,7 +177,8 @@ def _get_all_user_servers(user):
         return resources
 
     def get_server_url(pod):
-        url = "/jupyterhub/user/{username}/{servername}/".format(
+        url = "{jh_path_prefix}/user/{username}/{servername}/".format(
+            jh_path_prefix=config.JUPYTERHUB_PATH_PREFIX.rstrip("/"),
             username=pod.metadata.annotations["hub.jupyter.org/username"],
             servername=pod.metadata.annotations["hub.jupyter.org/servername"],
         )

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -143,9 +143,9 @@ def test_can_get_server_options(client):
 
 
 @pytest.mark.parametrize("gitlab", [NON_DEVELOPER_ACCESS], indirect=True)
-def test_users_with_no_developer_access_cannot_create_notebooks(client, gitlab):
+def test_users_with_no_developer_access_can_create_notebooks(client, gitlab):
     response = create_notebook_with_default_parameters(client)
-    assert response.status_code == 401
+    assert response.status_code == 201
 
 
 def test_getting_logs_for_nonexisting_notebook_returns_404(client):


### PR DESCRIPTION
- Enable the use of tmpauthenticator for Jupyterhub authentication.
  This enables notebook sessions for logged-out users. Closes #171

- Enable logged in users without write access to a project to start
  notebook servers from the project. Closes #275