### PR TITLE
Fix for gitlab URL

### DIFF
--- a/helm-chart/make-values-tmp.py
+++ b/helm-chart/make-values-tmp.py
@@ -44,6 +44,7 @@ def main():
     new_values["global"] = {
         "renku": {"domain": values["global"]["renku"]["domain"]},
         "useHTTPS": values["global"]["useHTTPS"],
+        "gitlab": {"urlPrefix": values["global"]["gitlab"]["urlPrefix"]},
     }
 
     hub_section = new_values["jupyterhub"]["hub"]


### PR DESCRIPTION
This is needed for some deployments that dont have `gitlab.url` configured