### PR TITLE
chore: obscure oauth token

### DIFF
--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -11,12 +11,29 @@ else
   LFS_SKIP_SMUDGE="--skip-smudge";
 fi
 
+# clear path
 rm -rf ${MOUNT_PATH}/*
 (rm -rf ${MOUNT_PATH}/.* || true)
+
+# set up git defaults
 git config --system push.default simple
-git lfs install $LFS_SKIP_SMUDGE --system
-git clone $REPOSITORY ${MOUNT_PATH}
+
+# extract the GitLab host and path
+pat='^(http[s]?:\/\/)([^:\/\s]+)\/?([a-zA-Z0-9_]+)?$'
+[[ $GITLAB_URL =~ $pat ]]
+GITLAB_HOST="${BASH_REMATCH[2]}"
+GITLAB_PATH="${BASH_REMATCH[3]}"
+
+# set up the repo
+mkdir -p $MOUNT_PATH
+cd $MOUNT_PATH
+git init
 git lfs install $LFS_SKIP_SMUDGE --local
+git config credential.helper "store --file=.git/credentials"
+echo "https://oauth2:${GITLAB_OAUTH_TOKEN}@${GITLAB_HOST}" > .git/credentials
+git remote add origin $REPOSITORY
+git fetch origin
+git checkout master
 
 if [ "${GITLAB_AUTOSAVE}" == "1" ] ; then
 

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -18,7 +18,7 @@ rm -rf ${MOUNT_PATH}/*
 git config --system push.default simple
 
 # extract the GitLab host and path
-pat='^(http[s]?:\/\/)([^\/]+)\/?([a-zA-Z0-9_\/\-]+)?$'
+pat='^(http[s]?:\/\/)([^\/]+)\/?([a-zA-Z0-9_\/\-]+?)$'
 [[ $GITLAB_URL =~ $pat ]]
 GITLAB_HOST="${BASH_REMATCH[2]}"
 GITLAB_PATH="${BASH_REMATCH[3]}"

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -19,7 +19,7 @@ rm -rf ${MOUNT_PATH}/*
 git config --system push.default simple
 
 # extract the GitLab host and path
-pat='^(http[s]?:\/\/)([^:\/\s]+)\/?([a-zA-Z0-9_]+)?$'
+pat='^(http[s]?:\/\/)([^\/]+)\/?([a-zA-Z0-9_\/\-]+)?$'
 [[ $GITLAB_URL =~ $pat ]]
 GITLAB_HOST="${BASH_REMATCH[2]}"
 GITLAB_PATH="${BASH_REMATCH[3]}"

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -3,7 +3,6 @@
 # The entrypoint removes the previous mount-path and does a fresh
 # checkout of the repository. It also initializes git lfs and sets
 # the proper file permissions.
-set -x
 
 if [ "$LFS_AUTO_FETCH" = 1 ]; then
   LFS_SKIP_SMUDGE="";
@@ -33,7 +32,6 @@ git config credential.helper "store --file=.git/credentials"
 echo "https://oauth2:${GITLAB_OAUTH_TOKEN}@${GITLAB_HOST}" > .git/credentials
 git remote add origin $REPOSITORY
 git fetch origin
-git checkout master
 
 if [ "${GITLAB_AUTOSAVE}" == "1" ] ; then
 


### PR DESCRIPTION
This PR restructures the git-clone entrypoint to inject the user's credentials into a credential-helper file so as to hide the token from the remote URL. 

This configuration is running on https://rok.dev.renku.ch

To test, launch an environment in the test deployment above and try to push a chance to one of your projects. See that `git remote -v` shows no oauth token. 

closes #313 