### PR TITLE
fix(app): escape username in registry secret name

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -18,9 +18,10 @@
 """Notebooks service API."""
 import json
 import os
-from kubernetes.client.rest import ApiException
 
+import escapism
 from flask import Blueprint, abort, current_app, jsonify, request, make_response
+from kubernetes.client.rest import ApiException
 
 from .. import config
 from ..util.gitlab_ import (
@@ -146,7 +147,8 @@ def launch_notebook(user):
 
     # only create a pull secret if the project has limited visibility and a token is available
     if config.GITLAB_AUTH and gl_project.visibility in {"private", "internal"}:
-        secret_name = f"{user.get('name')}-registry"
+        safe_username = escapism.escape(user.get("name"), escape_char="-").lower()
+        secret_name = f"{safe_username}-registry"
         create_or_replace_registry_secret(user, namespace, secret_name)
         payload["image_pull_secrets"] = [secret_name]
 


### PR DESCRIPTION
This PR fixes the problem that users with an underscore in their username have seen when launching notebooks from private repos.
Closes #393.
