### PR TITLE
chore(ci): move to github dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"


### PR DESCRIPTION
This PR adds the pattern that we already use on the renku-gateway for grouping dependency update PRs.