### PR TITLE
feat: restrict user pod egress

### DIFF
--- a/helm-chart/renku-notebooks/templates/user-pod-egress.yaml
+++ b/helm-chart/renku-notebooks/templates/user-pod-egress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.restrictUserPodEgress -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "notebooks.fullname" . }}-user-pod-egress
+  labels:
+    app: {{ template "notebooks.name" . }}
+    chart: {{ template "notebooks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  policyTypes:
+  - Egress
+  egress: 
+  - to:
+    # allow DNS resolution (internal and external)
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - to:
+    # allow connection to internal apps that is necessary
+    - podSelector:
+        matchLabels:
+          app: jupyterhub
+          component: hub
+  - to:
+    # allow access to web outside of cluster only
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+    ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: jupyterhub
+      component: singleuser-server
+{{- end -}}

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -227,8 +227,8 @@ jupyterhub:
 
 git_clone:
   image:
-    name: olevski90/git-clone
-    tag: '0.8.2-d2feebe'
+    name: renku/git-clone
+    tag: 'latest'
 
 service:
   type: ClusterIP

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -268,3 +268,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Restricts egress from the jupyterlab user pods only to DNS (internal and external), external IPs
+# and the jupyterhub service pods, setting this to false results in fully unrestricted egress.
+restrictUserPodEgress: true

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -29,8 +29,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 50
 
 image:
-  repository: olevski90/renku-notebooks
-  tag: '0.8.2-bd7f6b8'
+  repository: renku/renku-notebooks
+  tag: 'latest'
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -97,8 +97,8 @@ jupyterhub:
     db:
       upgrade: true
     image:
-      name: olevski90/jupyterhub-k8s
-      tag: '0.8.2-995651e'
+      name: renku/jupyterhub-k8s
+      tag: 'latest'
     allowNamedServers: true
     services:
       notebooks:

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -29,8 +29,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 50
 
 image:
-  repository: renku/renku-notebooks
-  tag: 'latest'
+  repository: olevski90/renku-notebooks
+  tag: '0.8.2-bd7f6b8'
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -97,8 +97,8 @@ jupyterhub:
     db:
       upgrade: true
     image:
-      name: renku/jupyterhub-k8s
-      tag: 'latest'
+      name: olevski90/jupyterhub-k8s
+      tag: '0.8.2-995651e'
     allowNamedServers: true
     services:
       notebooks:
@@ -227,8 +227,8 @@ jupyterhub:
 
 git_clone:
   image:
-    name: renku/git-clone
-    tag: 'latest'
+    name: olevski90/git-clone
+    tag: '0.8.2-d2feebe'
 
 service:
   type: ClusterIP
@@ -271,4 +271,4 @@ affinity: {}
 
 # Restricts egress from the jupyterlab user pods only to DNS (internal and external), external IPs
 # and the jupyterhub service pods, setting this to false results in fully unrestricted egress.
-restrictUserPodEgress: true
+restrictUserPodEgress: false


### PR DESCRIPTION
Closes #413 

This is a continuation of this PR: https://github.com/SwissDataScienceCenter/renku/pull/1541 which was posted on the renku repo but it should have been here. 

I retested the proposed changes in the code to make sure it works. Currently this is in place at tasko.dev.renku.ch.

As expected once the policy is active, the user cannot even get a 401 (Unauthorized) response from any of the internal kubernetes pods/components that are in the same node/cluster. However egress from the user pod to the internet and to DNS services (both inside and outside of the cluster) is not restricted at all.