### PR TITLE
Remove service links from user pods

### DIFF
--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -299,7 +299,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         # set the image pull policy
         self.image_pull_policy = "Always"
 
-        # Disable service links to prevent a lot of environment variables appearing in user environment
+        # Prevent kubernetes service links from appearing in user environment
         self.extra_pod_config = { "enableServiceLinks": False }
 
         pod = yield super().get_pod_manifest()

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -299,6 +299,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         # set the image pull policy
         self.image_pull_policy = "Always"
 
+        # Disable service links to prevent a lot of environment variables appearing in user environment
+        self.extra_pod_config = { "enableServiceLinks": False }
+
         pod = yield super().get_pod_manifest()
 
         # Because repository comes from a coroutine, we can't put it simply in `get_env()`
@@ -313,8 +316,5 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
                 for name in options.get("image_pull_secrets")
             ]
             pod.spec.image_pull_secrets = secrets
-
-        # Disable service links to prevent a lot of environment variables appearing in user environment
-        pod.spec.enableServiceLinks = False
 
         return pod

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -314,4 +314,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             ]
             pod.spec.image_pull_secrets = secrets
 
+        # Disable service links to prevent a lot of environment variables appearing in user environment
+        pod.spec.enableServiceLinks = False
+
         return pod


### PR DESCRIPTION
Closes #155 

Number of env variables on renkulab.io freshly made project:
```
 work ❯ test1 ▶ master ▶ $ ▶ env | wc -l
258
```

After setting enableServiceLinks to false:
```
 work ❯ test10 ▶ master ▶ $ ▶ env | wc -l
66
```