### PR TITLE
bug: Truncate secret-cull cronjob and pod names to be within k8s limits

### DIFF
--- a/helm-chart/renku-notebooks/templates/cronjob.yaml
+++ b/helm-chart/renku-notebooks/templates/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           securityContext:
             runAsUser: 1000
           containers:
-          - name: {{ .Chart.Name | trunc 21 | trimSuffix "-" }}-remove-user-registry-secrets
+          - name: {{ .Chart.Name | trunc 28 | trimSuffix "-" }}-cull-registry-secrets
             image: "{{ .Values.cull_secrets.image.repository }}:{{ .Values.cull_secrets.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command: ["python", "/cull_secrets/clean_user_registry_secrets.py"]

--- a/helm-chart/renku-notebooks/templates/cronjob.yaml
+++ b/helm-chart/renku-notebooks/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "notebooks.fullname" . | trunc 23 | trimSuffix "-" }}-remove-user-registry-secrets
+  name: {{ include "notebooks.fullname" . | trunc 30 | trimSuffix "-" }}-cull-registry-secrets
   labels:
     app: {{ template "notebooks.name" . }}
     chart: {{ template "notebooks.chart" . }}

--- a/helm-chart/renku-notebooks/templates/cronjob.yaml
+++ b/helm-chart/renku-notebooks/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "notebooks.fullname" . }}-remove-user-registry-secrets
+  name: {{ include "notebooks.fullname" . | trunc 23 | trimSuffix "-" }}-remove-user-registry-secrets
   labels:
     app: {{ template "notebooks.name" . }}
     chart: {{ template "notebooks.chart" . }}
@@ -18,7 +18,7 @@ spec:
           securityContext:
             runAsUser: 1000
           containers:
-          - name: {{ .Chart.Name }}-remove-user-registry-secrets
+          - name: {{ .Chart.Name | trunc 21 | trimSuffix "-" }}-remove-user-registry-secrets
             image: "{{ .Values.cull_secrets.image.repository }}:{{ .Values.cull_secrets.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command: ["python", "/cull_secrets/clean_user_registry_secrets.py"]


### PR DESCRIPTION
I forgot completely about this, my bad. Virginia came across this issue, see [here](https://swiss-data-science.slack.com/archives/G67N59QL8/p1603811018093200).

I currently tested that this will deploy in my namespace with the changes. I am not sure exactly what I have to change to get a longer name without making a new namespace. I did test by decreasing the limit further so that I see the cronjob in my namespace show up with a truncated name and it works.

I also made sure that the container name that cronjob creates is less than the 63 character limit.

The math for the truncation is as follows:
- cronjob name: 
  - limit of 52 characters 
  - minus 22 characters for `-cull-registry-secrets` 
  - = 30
- name of each pod launched by cronjob: 
  - limit of 63 characters 
  - minus 22 characters for `-cull-registry-secrets` 
  - minus 13 characters for the added `-` and 12 character random string added by k8s
  - = 28