### PR TITLE
fix: properly recognize pod status when terminating

### DIFF
--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -153,7 +153,11 @@ def _get_all_user_servers(user):
         ready = True
         try:
             for status in pod.status.container_statuses:
-                ready = ready and status.ready
+                ready = (
+                    ready
+                    and status.ready
+                    and pod.metadata.get("deletionTimestamp", None) is not None
+                )
         except (IndexError, TypeError):
             ready = False
 

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -156,7 +156,6 @@ def _get_all_user_servers(user):
                 ready = (
                     ready
                     and status.ready
-                    and getattr(pod.metadata, "deletion_timestamp", None) is None
                 )
         except (IndexError, TypeError):
             ready = False

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -156,7 +156,7 @@ def _get_all_user_servers(user):
                 ready = (
                     ready
                     and status.ready
-                    and pod.metadata.get("deletionTimestamp", None) is None
+                    and getattr(pod.metadata, "deletionTimestamp", None) is None
                 )
         except (IndexError, TypeError):
             ready = False

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -150,8 +150,10 @@ def _get_all_user_servers(user):
         return {"step": c.type, "message": c.message, "reason": c.reason}
 
     def get_pod_status(pod):
+        ready = True
         try:
-            ready = pod.status.container_statuses[0].ready
+            for status in pod.status.container_statuses:
+                ready = ready and status.ready
         except (IndexError, TypeError):
             ready = False
 
@@ -162,17 +164,19 @@ def _get_all_user_servers(user):
 
     def get_pod_resources(pod):
         try:
-            resources = pod.spec.containers[0].resources.requests
-            # translate the cpu weird numeric string to a normal number
-            # ref: https://kubernetes.io/docs/concepts/configuration/
-            #   manage-compute-resources-container/#how-pods-with-resource-limits-are-run
-            if (
-                "cpu" in resources
-                and isinstance(resources["cpu"], str)
-                and str.endswith(resources["cpu"], "m")
-                and resources["cpu"][:-1].isdigit()
-            ):
-                resources["cpu"] = str(int(resources["cpu"][:-1]) / 1000)
+            for container in pod.spec.containers:
+                if container.name == "notebook":
+                    resources = container.resources.requests
+                    # translate the cpu weird numeric string to a normal number
+                    # ref: https://kubernetes.io/docs/concepts/configuration/
+                    #   manage-compute-resources-container/#how-pods-with-resource-limits-are-run
+                    if (
+                        "cpu" in resources
+                        and isinstance(resources["cpu"], str)
+                        and str.endswith(resources["cpu"], "m")
+                        and resources["cpu"][:-1].isdigit()
+                    ):
+                        resources["cpu"] = str(int(resources["cpu"][:-1]) / 1000)
         except (AttributeError, IndexError):
             resources = {}
         return resources

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -150,7 +150,7 @@ def _get_all_user_servers(user):
         return {"step": c.type, "message": c.message, "reason": c.reason}
 
     def get_pod_status(pod):
-        ready = True
+        ready = getattr(pod.metadata, "deletion_timestamp", None) is None
         try:
             for status in pod.status.container_statuses:
                 ready = (

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -156,7 +156,7 @@ def _get_all_user_servers(user):
                 ready = (
                     ready
                     and status.ready
-                    and getattr(pod.metadata, "deletionTimestamp", None) is None
+                    and getattr(pod.metadata, "deletion_timestamp", None) is None
                 )
         except (IndexError, TypeError):
             ready = False

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -153,10 +153,7 @@ def _get_all_user_servers(user):
         ready = getattr(pod.metadata, "deletion_timestamp", None) is None
         try:
             for status in pod.status.container_statuses:
-                ready = (
-                    ready
-                    and status.ready
-                )
+                ready = ready and status.ready
         except (IndexError, TypeError):
             ready = False
 

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -156,7 +156,7 @@ def _get_all_user_servers(user):
                 ready = (
                     ready
                     and status.ready
-                    and pod.metadata.get("deletionTimestamp", None) is not None
+                    and pod.metadata.get("deletionTimestamp", None) is None
                 )
         except (IndexError, TypeError):
             ready = False


### PR DESCRIPTION
closes #496 

Basically with the addition of the http proxy container in the pod the status of the pod cannot be determined just from one container. In addition even with a single container we had a problem where the "Terminating" status was not properly recognized. It seems that the only way that the "Terminating" status can be recognized is by checking whether `pod.metadata.deletionTimestamp` is None or not.