### PR TITLE
chore: update documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,8 +143,8 @@ Look up the name of the proxy pod and set up a port-forward, e.g.
     kubectl port-forward proxy-747596c4f4-wdmfs 31212:8000
 
 You can now visit http://localhost:31212/services/notebooks/user
-which should log you in to gitlab.com and show your user information. To
-launch a notebook server, you need to obtain a token from
+which should prompt you to log in to gitlab.com and then show your 
+user information. To launch a notebook server, you need to obtain a token from
 http://localhost:31212/hub/token and use it in the ``POST`` request:
 
 .. code-block:: console

--- a/README.rst
+++ b/README.rst
@@ -123,8 +123,12 @@ You can then deploy JupyterHub and the notebooks service with helm:
 
     helm upgrade --install renku-notebooks \
       -f minikube-values.yaml \
-      --set global.renku.domain$(minikube ip):31212 \
+      --set global.renku.domain=$(minikube ip):31212 \
       renku-notebooks
+
+Please note that by default this will deploy renku-notebooks against `https://gitlab.com`.
+If you have a different GitLab instance you would like to use, make sure you update
+the `minikube-values.yaml` accordingly.
 
 Look up the name of the proxy pod and set up a port-forward, e.g.
 
@@ -138,17 +142,22 @@ Look up the name of the proxy pod and set up a port-forward, e.g.
 
     kubectl port-forward proxy-747596c4f4-wdmfs 31212:8000
 
-You can now visit http://localhost:31212/jupyterhub/services/notebooks/user
+You can now visit http://localhost:31212/services/notebooks/user
 which should log you in to gitlab.com and show your user information. To
 launch a notebook server, you need to obtain a token from
 http://localhost:31212/hub/token and use it in the ``POST`` request:
 
 .. code-block:: console
 
-    curl -X POST \
-    http://localhost:31212/services/notebooks/<namespace>/<project>/<commit-sha> \
-    -H "Authorization: token <token>"
+    curl --location --request POST 'http://localhost:31212/services/notebooks/servers' \
+    --header 'Authorization: token <jupyterhub token>' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"namespace":"gitlab-username","project":"gitlab-project-name","commit_sha":"2dd7f2a2b245494aad2365c8d56e6474600c7efa"}'
 
+If the request was sucessful you will get a JSON response with details 
+about the user server that you just launched. To use the server in the 
+browser visit http://localhost:31212/hub/home where you should 
+see the server you just launched and a link to acess it.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,9 @@ The service defines these endpoints:
 
 ``POST <service-prefix>/servers``: start a notebook server for the user. A JSON
 payload with at least ``namespace``, ``project``, and ``commit_sha`` fields must
-be provided. It may contain optional ``branch`` and ``notebook`` fields as well.
-if ``branch`` is not provided, the default is ``master``). Note that if multiple
+be provided. It may contain optional ``branch``, ``image`` and ``notebook`` fields as well
+(if ``branch`` is not provided, the default is ``master``). If ``image`` is not provided
+the image associated with the specified commit SHA is used. Note that if multiple
 users request the same ``namespace``, ``project``, ``branch``, and
 ``commit_sha`` each user receives their own notebook server.
 

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ http://localhost:31212/hub/token and use it in the ``POST`` request:
 If the request was sucessful you will get a JSON response with details 
 about the user server that you just launched. To use the server in the 
 browser visit http://localhost:31212/hub/home where you should 
-see the server you just launched and a link to acess it.
+see the server you just launched and a link to access it.
 
 Contributing
 ------------

--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -59,4 +59,3 @@ jupyterhub:
       clientId: <application ID code from gitlab>
       clientSecret: <application secret code from gitlab>
       callbackUrl: http://localhost:31212/hub/oauth_callback
-      

--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -39,8 +39,12 @@ jupyterhub:
       notebooks:
         apiToken: notebookstoken
     extraEnv:
-      IMAGE_REGISTRY: *gitlab_registry
-      GITLAB_URL: *gitlab_url
+    - name: GITLAB_URL
+      value: *gitlab_url
+    - name: IMAGE_REGISTRY
+      value: *gitlab_registry
+    - name: JUPYTERHUB_SPAWNER_CLASS
+      value: spawners.RenkuKubeSpawner
   proxy:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255
     service:
@@ -52,5 +56,7 @@ jupyterhub:
       enabled: true
       cryptoKey: 86282f03d9886a64a46ee38f946e9ee27a600df4559584eeb90d0bfbd5a3dc0e
     gitlab:
-      clientId: 75be9e2e28203c3c44272c72142a839956cfc07e1a0ab93a5d7c9ac6c7802b58
-      clientSecret: 4bd8a67690d4a102436d15fa82b793d73046d350372ee6bd0302617298d08092
+      clientId: <application ID code from gitlab>
+      clientSecret: <application secret code from gitlab>
+      callbackUrl: http://localhost:31212/hub/oauth_callback
+      


### PR DESCRIPTION
closes #144 

The only thing I had to fix was the description of the endpoints and the instructions to start renku-notebooks with minikube and an existing gitlab deployment.

I tested that with the new instructions one can deploy renku-notebooks with minikube and launch and access a server.