### PR TITLE
fix: checking and deleting secrets without annotations and labels

### DIFF
--- a/cull_secrets/clean_user_registry_secrets.py
+++ b/cull_secrets/clean_user_registry_secrets.py
@@ -98,6 +98,8 @@ def remove_user_registry_secret(namespace, k8s_client, max_secret_age_hrs=0.25):
         if (
             secret_name_match is not None
             and secret.type == "kubernetes.io/dockerconfigjson"
+            and secret.metadata.annotations is not None
+            and secret.metadata.labels is not None
             and all(
                 [
                     # check that label keys for sha, username, namespace are present


### PR DESCRIPTION
I noticed that the cull image pull secrets jobs were failing with the following message.

```
INFO:root:Checking for user registry secrets whose names match the regex: .+-registry-[a-z0-9-]{36}$
Traceback (most recent call last):
  File "/cull_secrets/clean_user_registry_secrets.py", line 187, in <module>
    main()
  File "/cull_secrets/clean_user_registry_secrets.py", line 183, in main
    remove_user_registry_secret(args.namespace, k8s_client, args.age_hours_minimum)
  File "/cull_secrets/clean_user_registry_secrets.py", line 112, in remove_user_registry_secret
    for annotation_key in POD_ANNOTATIONS
  File "/cull_secrets/clean_user_registry_secrets.py", line 112, in <listcomp>
    for annotation_key in POD_ANNOTATIONS
AttributeError: 'NoneType' object has no attribute 'keys'
```

The problem is occurring because for any secret that has no annotations or labels the python k8s client returns None instead of an empty dictionary. But when annotations are present then `secret.metadata.annotations` are a dictionary of the annotation names and their values. The same occurs with the labels.

This problem occurred only on dev because there we had some old image pull registry secrets that did not have any annotations and/or labels and were causing this failure. In my testing environment I never had such a secret. This corrects the problem.

I confirmed I can trigger the error by making a specific secret that passes some of the initial conditions of the if statement that was changed here but without annotations. Also I tested to make sure that with this change the error does not occur anymore.