### PR TITLE
fix: extraEnv requires only string values now

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -117,7 +117,7 @@ jupyterhub:
         # apiToken: Generate with `openssl rand -hex 32`
         # oauth_redirect_uri: https://<renku-domain>/api/auth/jupyterhub/token
     extraEnv:
-      DEBUG: 1
+      DEBUG: '1'
       JUPYTERHUB_SPAWNER_CLASS: spawners.RenkuKubeSpawner
       ## GitLab instance URL
       # GITLAB_URL: http://gitlab.com


### PR DESCRIPTION
So I saw the `helm lint` failed after the latest changes. But the line that causes the failure has not been changed in months.

I think this is occurring because jupyterhub was upgraded.

This is the line in the jupyterhub helm chart _helpers.tpl that causes [this problem](https://github.com/SwissDataScienceCenter/renku-notebooks/runs/1707349028):
```
{{- else if eq (typeOf $value) "string" -}}
- name: {{ $key | quote }}
  value: {{ $value | quote | println }}
{{- else }}
{{- printf "?.extraEnv.%s had an unexpected type (%s)" $key (typeOf $value) | fail }}
{{- end }}
```
It seems that before non-string values were allowed in the extraEnv part, but not anymore. The lint command passes after this.