### PR TITLE
fix: remove unnecessary log error calls

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -309,8 +309,6 @@ def stop_server(user, forced, server_name):
         return make_response(jsonify({"messages": {"error": "Server not found."}}), 404)
 
     r = delete_named_server(user, server_name)
-    current_app.logger.error(f"The return code is {r.status_code}")
-    current_app.logger.error(f"The return content is {r.text}")
     if r.status_code == 204:
         return "", 204
     elif r.status_code == 202:


### PR DESCRIPTION
Fixes: 
- https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/4937/events/1175997ba7994c0a9a23e07645d8ed7f/
- https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/4936/events/8274de23f69f43db9e0ac3772350a3cd/

This occurs because of leftover logger.error statements that I was using when working on the code and dubugging. These are not real errors. These should have been removed.