### PR TITLE
fix: pod resources schema

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -77,21 +77,15 @@ class UserPodAnnotations(
         return flatten_dict(data)
 
 
-class UserPodResources(
-    Schema.from_dict(
-        {
-            "cpu": fields.Str(required=True),
-            "memory": fields.Str(required=True),
-            "ephemeral-storage": fields.Str(required=False),
-        }
-    )
-):
-    """
-    Memory and CPU resources that should be present in the response to creating a
-    jupyterhub noteboooks server.
-    """
-
-    pass
+UserPodResources = Schema.from_dict(
+    # Memory and CPU resources that should be present in the response to creating a
+    # jupyterhub noteboooks server.
+    {
+        "cpu": fields.Str(required=True),
+        "memory": fields.Str(required=True),
+        "ephemeral-storage": fields.Str(required=False),
+    }
+)
 
 
 class LaunchNotebookResponse(Schema):

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -77,14 +77,21 @@ class UserPodAnnotations(
         return flatten_dict(data)
 
 
-class UserPodResources(Schema):
+class UserPodResources(
+    Schema.from_dict(
+        {
+            "cpu": fields.Str(required=True),
+            "memory": fields.Str(required=True),
+            "ephemeral-storage": fields.Str(required=False),
+        }
+    )
+):
     """
     Memory and CPU resources that should be present in the response to creating a
     jupyterhub noteboooks server.
     """
 
-    cpu = fields.Str()
-    memory = fields.Str()
+    pass
 
 
 class LaunchNotebookResponse(Schema):
@@ -96,7 +103,7 @@ class LaunchNotebookResponse(Schema):
     annotations = fields.Nested(UserPodAnnotations())
     name = fields.Str()
     state = fields.Dict()
-    started = fields.DateTime(format="iso")
+    started = fields.DateTime(format="iso", allow_none=True)
     status = fields.Dict()
     url = fields.Str()
     resources = fields.Nested(UserPodResources())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,10 +306,15 @@ def kubernetes_client_full(mocker):
                     "spec": {
                         "containers": [
                             {
+                                "name": "notebook",
                                 "image": "registry.fakegitlab.renku.ch/"
                                 "dummynamespace/dummyproject:01234567",
                                 "resources": {
-                                    "requests": {"cpu": "500m", "memory": "2147483648"}
+                                    "requests": {
+                                        "cpu": "500m",
+                                        "memory": "2147483648",
+                                        "ephemeral-storage": "20Gi",
+                                    }
                                 },
                             }
                         ]


### PR DESCRIPTION
This will address the following errors:
- https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/4940/events/57bfd7f7151d4d5bb11d08825e054325/
- https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/4939/events/9c1dce46c5c94a8a9ee3511f367b2082/

The issues were occurring because:
- now we also have an `ephemeral-storage` variable that we did not know before in the pod resources
- the timestamp that when the pod starts can be `null` sometimes instead of a timestamp