### PR TITLE
fix: duplicate https proxy containers

### DIFF
--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -167,6 +167,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         repository = yield self.git_repository()
         options = self.user_options
         auth_state = yield self.user.get_auth_state()
+        extra_containers = []
 
         if GITLAB_AUTH:
             assert "access_token" in auth_state
@@ -273,10 +274,8 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             ],
             image=options.get("git_https_proxy_image"),
         )
-        self.extra_containers = list(
-            filter(lambda x: getattr(x, "name", None) != "git-https-proxy", self.extra_containers)
-        )
-        self.extra_containers.append(https_proxy)
+        extra_containers.append(https_proxy)
+        self.extra_containers = extra_containers
 
         # Finalize the pod configuration
 

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -273,6 +273,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             ],
             image=options.get("git_https_proxy_image"),
         )
+        self.extra_containers = list(
+            filter(lambda x: x.name != "git-https-proxy", self.extra_containers)
+        )
         self.extra_containers.append(https_proxy)
 
         # Finalize the pod configuration

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -274,7 +274,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             image=options.get("git_https_proxy_image"),
         )
         self.extra_containers = list(
-            filter(lambda x: x.name != "git-https-proxy", self.extra_containers)
+            filter(lambda x: getattr(x, "name", None) != "git-https-proxy", self.extra_containers)
         )
         self.extra_containers.append(https_proxy)
 

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -167,7 +167,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         repository = yield self.git_repository()
         options = self.user_options
         auth_state = yield self.user.get_auth_state()
-        extra_containers = []
+        self.extra_containers = []
 
         if GITLAB_AUTH:
             assert "access_token" in auth_state
@@ -274,8 +274,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             ],
             image=options.get("git_https_proxy_image"),
         )
-        extra_containers.append(https_proxy)
-        self.extra_containers = extra_containers
+        self.extra_containers.append(https_proxy)
 
         # Finalize the pod configuration
 


### PR DESCRIPTION
At first we suspected that the cause of these types of [errors](https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/4994/activity/?environment=renku-ci&environment=renku-dev&project=4&query=is%3Aunresolved) is just the jupyterhub pod in k8s not being properly updated and holding an old config or something like that. Because killing the `hub-*` pod would always resolve the issue. 

However we see that killing the `hub-*` pod only temporarily resolves things. This is because the `KubeSpawner` keeps instances of all servers and sometimes reuses them. Therefore by simply appending to the list of `extra_containers` in the spawner we were getting in a situation (in some edge case) where the spawner which already contains `https-proxy` as an extra container is reused and the same `https-proxy` container is added twice... Resulting in the error we see in sentry because k8s cannot have two or more containers with the same name in a single pod.

This should resolve this problem.