### PR TITLE
feat: validate server options

### DIFF
--- a/helm-chart/renku-notebooks/values.schema.json
+++ b/helm-chart/renku-notebooks/values.schema.json
@@ -1,0 +1,208 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "informationAmount": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]*|[0-9]\\.[0-9]*)[EPTGMK][i]{0,1}$"
+        },
+        "cpuRequest": {
+            "type": "number",
+            "exclusiveMinimum": 0.0,
+            "multipleOf": 0.001
+        },
+        "gpuRequest": {
+            "type": "integer",
+            "minimum": 0.0
+        },
+        "serverOption": {
+            "type": "object",
+            "properties": {
+                "order": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "displayName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "order",
+                "displayName"
+            ]
+        },
+        "serverOptionEnumStr": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/serverOption"
+                },
+                {
+                    "properties": {
+                        "order": true,
+                        "displayName": true,
+                        "type": {
+                            "type": "string",
+                            "pattern": "^enum$"
+                        },
+                        "default": {
+                            "type": "string"
+                        },
+                        "options": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "default",
+                        "options"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "serverOptionBool": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/serverOption"
+                },
+                {
+                    "properties": {
+                        "order": true,
+                        "displayName": true,
+                        "type": {
+                            "type": "string",
+                            "pattern": "^boolean$"
+                        },
+                        "default": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "default"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "serverOptionGpu": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/serverOption"
+                },
+                {
+                    "properties": {
+                        "order": true,
+                        "displayName": true,
+                        "type": {
+                            "type": "string",
+                            "pattern": "^enum$"
+                        },
+                        "default": { "$ref": "#/definitions/gpuRequest" },
+                        "options": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/gpuRequest" },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "default",
+                        "options"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "serverOptionCpu": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/serverOption"
+                },
+                {
+                    "properties": {
+                        "order": true,
+                        "displayName": true,
+                        "type": {
+                            "type": "string",
+                            "pattern": "^enum$"
+                        },
+                        "default": { "$ref": "#/definitions/cpuRequest" },
+                        "options": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/cpuRequest" },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "default",
+                        "options"
+                    ],
+                    "additionalProperties": false 
+                }
+            ]
+        },
+        "serverOptionMemory": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/serverOptionEnumStr"
+                },
+                {
+                    "properties": {
+                        "order": true,
+                        "displayName": true,
+                        "type": {
+                            "type": "string",
+                            "pattern": "^enum$"
+                        },
+                        "default": { "$ref": "#/definitions/informationAmount" },
+                        "options": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/informationAmount" },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "default",
+                        "options"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "properties": {
+        "serverOptions": {
+            "description": "Options provided to the user in the UI when launching a server.",
+            "properties": {
+                "defaultUrl": { "$ref": "#/definitions/serverOptionEnumStr" },
+                "cpu_request": { "$ref": "#/definitions/serverOptionCpu" },
+                "mem_request": { "$ref": "#/definitions/serverOptionMemory" },
+                "lfs_auto_fetch": { "$ref": "#/definitions/serverOptionBool" },
+                "gpu_request": { "$ref": "#/definitions/serverOptionGpu" }
+            },
+            "required": [
+                "defaultUrl",
+                "cpu_request",
+                "mem_request",
+                "lfs_auto_fetch"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "serverOptions"
+    ],
+    "title": "Values",
+    "type": "object"
+}

--- a/renku_notebooks/api/custom_fields.py
+++ b/renku_notebooks/api/custom_fields.py
@@ -1,6 +1,7 @@
 from typing import List, Mapping, Any
 from marshmallow import fields
 from marshmallow.exceptions import ValidationError
+import re
 
 
 class UnionField(fields.Field):
@@ -48,3 +49,13 @@ class UnionField(fields.Field):
                 errors.append(error.messages)
 
         raise ValidationError(errors)
+
+
+serverOptionCpuValue = fields.Number(
+    validate=lambda x: x > 0.0 and (x % 1 >= 0.001 or x % 1 == 0.0), required=True,
+)
+serverOptionMemoryValue = fields.String(
+    validate=lambda x: re.match(r"^(?:[1-9][0-9]*|[0-9]\.[0-9]*)[EPTGMK][i]{0,1}$", x)
+    is not None,
+    required=True,
+)

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -54,6 +54,7 @@ from .schemas import (
     ServerOptions,
     FailedParsing,
 )
+from ..util.misc import read_server_options_file
 
 
 bp = Blueprint("notebooks_blueprint", __name__, url_prefix=config.SERVICE_PREFIX)
@@ -140,7 +141,7 @@ def launch_notebook(
 
     # process the server options
     # server options from system configuration
-    server_options_defaults = _read_server_options_file()
+    server_options_defaults = read_server_options_file()
 
     # process the requested options and set others to defaults from config
     server_options.setdefault(
@@ -351,7 +352,7 @@ def stop_server(user, forced, server_name):
 @authenticated
 def server_options(user):
     """Return a set of configurable server options."""
-    server_options = _read_server_options_file()
+    server_options = read_server_options_file()
 
     # TODO: append image-specific options to the options json
     return jsonify(server_options)
@@ -396,12 +397,3 @@ def server_logs(user, server_name):
             jsonify({"messages": {"error": "Cannot find server"}}), 404
         )
     return response
-
-
-def _read_server_options_file():
-    server_options_file = os.getenv(
-        "NOTEBOOKS_SERVER_OPTIONS_PATH", "/etc/renku-notebooks/server_options.json"
-    )
-    with open(server_options_file) as f:
-        server_options = json.load(f)
-    return server_options

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -27,18 +27,15 @@ class LaunchNotebookRequestServerOptions(Schema):
     def validate_server_options(self, data, **kwargs):
         server_options = read_server_options_file()
         for option in data.keys():
-            if server_options.get(option, {}).get("type", None) == "boolean":
+            if option not in server_options.keys():
+                continue  # presence of option keys are already handled by marshmallow
+            if server_options[option]["type"] == "boolean":
                 continue  # boolean options are already validated by marshmallow
-            if server_options.get(  # validate options that can have a set of values
-                option, {}
-            ).get("options", None) is None or data[option] not in server_options.get(
-                option, {}
-            ).get(
-                "options", []
-            ):
+            if data[option] not in server_options[option]["options"]:
+                # validate options that can have a set of values against allowed values
                 raise ValidationError(
                     f"The value {data[option]} for sever option {option} is not valid, "
-                    f"has to be one of {server_options.get(option, {}).get('options', [])}"
+                    f"it has to be one of {server_options[option]['options']}"
                 )
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -25,7 +25,9 @@ class LaunchNotebookRequest(Schema):
     commit_sha = fields.Str(required=True)
     notebook = fields.Str(missing=None)
     image = fields.Str(missing=None)
-    server_options = fields.Nested(LaunchNotebookRequestServerOptions(), missing={})
+    server_options = fields.Nested(
+        LaunchNotebookRequestServerOptions(), missing={}, data_key="serverOptions"
+    )
 
 
 def flatten_dict(d, parent_key="", sep="."):

--- a/renku_notebooks/util/misc.py
+++ b/renku_notebooks/util/misc.py
@@ -1,0 +1,11 @@
+import json
+import os
+
+
+def read_server_options_file():
+    server_options_file = os.getenv(
+        "NOTEBOOKS_SERVER_OPTIONS_PATH", "/etc/renku-notebooks/server_options.json"
+    )
+    with open(server_options_file) as f:
+        server_options = json.load(f)
+    return server_options

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -177,6 +177,25 @@ def test_users_with_no_developer_access_can_create_notebooks(
     assert response.status_code == 202 or response.status_code == 201
 
 
+def test_launching_notebook_with_invalid_server_options(
+    client, gitlab, make_all_images_valid, kubernetes_client_empty,
+):
+    response = create_notebook(
+        client,
+        **{
+            **DEFAULT_PAYLOAD,
+            "serverOptions": {
+                "cpu_request": 20,
+                "defaultUrl": "some_url",
+                "gpu_request": 20,
+                "lfs_auto_fetch": True,
+                "mem_request": "100G",
+            },
+        },
+    )
+    assert response.status_code == 422
+
+
 def test_getting_logs_for_nonexisting_notebook_returns_404(
     client, kubernetes_client_empty
 ):


### PR DESCRIPTION
closes #71 

So I implemented evaluation on the helm chart values but only for the server options portion. I will add a new issue to add it for the whole values.yaml file.

I also added more detailed validation (in line with the values.yaml validation) for the API.

I did some digging online to see if marshmallow can parse jsonschema and convert to marshmallow type schemas and it cannot unfortunately. There is a library that can convert a marshmallow schema to jsonschema but it cannot include the custom validation we need for some of the server options stuff. So I think we unfortunately have to have this kind of duplication.

This is deployed at https://tasko.dev.renku.ch/