### PR TITLE
fix: unknown gpu field in resources request

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -143,7 +143,7 @@ class LaunchNotebookResponse(Schema):
     started = fields.DateTime(format="iso", allow_none=True)
     status = fields.Dict()
     url = fields.Str()
-    resources = fields.Nested(UserPodResources(unknown=INCLUDE))
+    resources = fields.Nested(UserPodResources())
     image = fields.Str()
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -5,6 +5,7 @@ from marshmallow import (
     post_dump,
     validates_schema,
     ValidationError,
+    INCLUDE,
 )
 import collections
 
@@ -134,7 +135,7 @@ class LaunchNotebookResponse(Schema):
     started = fields.DateTime(format="iso", allow_none=True)
     status = fields.Dict()
     url = fields.Str()
-    resources = fields.Nested(UserPodResources())
+    resources = fields.Nested(UserPodResources(unknown=INCLUDE))
     image = fields.Str()
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -5,7 +5,7 @@ from marshmallow import (
     post_dump,
     validates_schema,
     ValidationError,
-    INCLUDE,
+    pre_load,
 )
 import collections
 
@@ -112,15 +112,23 @@ class UserPodAnnotations(
         return flatten_dict(data)
 
 
-UserPodResources = Schema.from_dict(
-    # Memory and CPU resources that should be present in the response to creating a
-    # jupyterhub noteboooks server.
-    {
-        "cpu": fields.Str(required=True),
-        "memory": fields.Str(required=True),
-        "ephemeral-storage": fields.Str(required=False),
-    }
-)
+class UserPodResources(
+    Schema.from_dict(
+        # Memory and CPU resources that should be present in the response to creating a
+        # jupyterhub noteboooks server.
+        {
+            "cpu": fields.Str(required=True),
+            "memory": fields.Str(required=True),
+            "ephemeral-storage": fields.Str(required=False),
+            "gpu": fields.Str(required=False),
+        }
+    )
+):
+    @pre_load
+    def resolve_gpu_fieldname(self, in_data, **kwargs):
+        if "nvidia.com/gpu" in in_data.keys():
+            in_data["gpu"] = in_data.pop("nvidia.com/gpu")
+        return in_data
 
 
 class LaunchNotebookResponse(Schema):


### PR DESCRIPTION
Fixes these kind of errors on limited: https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/5096/?environment=renku-limited&project=4&referrer=alert_email

This is occurring because I did not test with an environment that actually has a gpu. And in the response after the sessions is created the JH reports not only the memory and cpu but also the gpu that was requested. The gpu was not added in the schemas so it is crashing on limited.

This should fix that.

/deploy