### PR TITLE
fix: do not check defaultUrl against list of server options

### DIFF
--- a/renku_notebooks/__init__.py
+++ b/renku_notebooks/__init__.py
@@ -91,6 +91,9 @@ def create_app():
     def handle_error(err):
         headers = err.data.get("headers", None)
         messages = err.data.get("messages", {"error": "Invalid request."})
+        app.logger.warning(
+            f"Validation of request parameters failed with the messages: {messages}"
+        )
         if headers:
             return jsonify({"messages": messages}), err.code, headers
         else:

--- a/renku_notebooks/api/custom_fields.py
+++ b/renku_notebooks/api/custom_fields.py
@@ -59,3 +59,7 @@ serverOptionMemoryValue = fields.String(
     is not None,
     required=True,
 )
+serverOptionUrlValue = fields.Str(
+    required=True,
+    validate=lambda x: re.match(r"^\/[a-zA-Z0-9\-\.\_\~\/]+", x) is not None,
+)

--- a/renku_notebooks/api/custom_fields.py
+++ b/renku_notebooks/api/custom_fields.py
@@ -61,5 +61,5 @@ serverOptionMemoryValue = fields.String(
 )
 serverOptionUrlValue = fields.Str(
     required=True,
-    validate=lambda x: re.match(r"^\/[a-zA-Z0-9\-\.\_\~\/]+", x) is not None,
+    validate=lambda x: re.match(r"^\/[a-zA-Z0-9\-\.\_\~\/]+$", x) is not None,
 )

--- a/renku_notebooks/api/custom_fields.py
+++ b/renku_notebooks/api/custom_fields.py
@@ -59,7 +59,4 @@ serverOptionMemoryValue = fields.String(
     is not None,
     required=True,
 )
-serverOptionUrlValue = fields.Str(
-    required=True,
-    validate=lambda x: re.match(r"^\/[a-zA-Z0-9\-\.\_\~\/]+$", x) is not None,
-)
+serverOptionUrlValue = fields.Str(required=True)

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -13,12 +13,13 @@ from .. import config
 from .custom_fields import (
     serverOptionCpuValue,
     serverOptionMemoryValue,
+    serverOptionUrlValue,
 )
 from ..util.misc import read_server_options_file
 
 
 class LaunchNotebookRequestServerOptions(Schema):
-    defaultUrl = fields.String(required=True)
+    defaultUrl = serverOptionUrlValue
     cpu_request = serverOptionCpuValue
     mem_request = serverOptionMemoryValue
     lfs_auto_fetch = fields.Bool(required=True)
@@ -30,6 +31,8 @@ class LaunchNotebookRequestServerOptions(Schema):
         for option in data.keys():
             if option not in server_options.keys():
                 continue  # presence of option keys are already handled by marshmallow
+            if option == "defaultUrl":
+                continue  # the defaultUrl field should not be limited to only server options
             if server_options[option]["type"] == "boolean":
                 continue  # boolean options are already validated by marshmallow
             if data[option] not in server_options[option]["options"]:
@@ -214,6 +217,15 @@ class ServerOptionString(ServerOptionBase):
     )
 
 
+class ServerOptionUrl(ServerOptionBase):
+    """The schema used to describe a single option for the server_options endpoint."""
+
+    default = serverOptionUrlValue
+    options = fields.List(
+        serverOptionUrlValue, validate=lambda x: len(x) >= 1, required=True
+    )
+
+
 class ServerOptionBool(ServerOptionBase):
     """The schema used to describe a single option for the server_options endpoint."""
 
@@ -227,7 +239,7 @@ class ServerOptions(Schema):
     """
 
     cpu_request = fields.Nested(ServerOptionCpu(), required=True)
-    defaultUrl = fields.Nested(ServerOptionString(), required=True)
+    defaultUrl = fields.Nested(ServerOptionUrl(), required=True)
     gpu_request = fields.Nested(ServerOptionGpu())
     lfs_auto_fetch = fields.Nested(ServerOptionBool(), required=True)
     mem_request = fields.Nested(ServerOptionMemory(), required=True)


### PR DESCRIPTION
So when I was implementing this feature, which prevents you from launching a notebook with more cpu/memory than what is specified in the server options, I forgot that the `defaultUrl` option should not fall in this category. Some people use this to launch notebooks or dashboards, etc on other urls.

/deploy