### PR TITLE
fix: allow and include unknown annotations in schema

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -6,6 +6,7 @@ from marshmallow import (
     validates_schema,
     ValidationError,
     pre_load,
+    INCLUDE,
 )
 import collections
 
@@ -99,6 +100,9 @@ class UserPodAnnotations(
     Used to validate the annotations of a jupyterhub user pod
     that are returned to the UI as part of any endpoint that list servers.
     """
+
+    class Meta:
+        unknown = INCLUDE
 
     def get_attribute(self, obj, key, *args, **kwargs):
         # in marshmallow, any schema key with a dot in it is converted to nested dictionaries

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,39 @@
+from marshmallow import ValidationError
+import pytest
+
+from renku_notebooks.api.schemas import UserPodAnnotations
+
+
+RENKU_ANNOTATION_PREFIX = "renku.io/"
+JUPYTERHUB_ANNOTATION_PREFIX = "hub.jupyter.org/"
+
+passing_annotation_response = {
+    f"{RENKU_ANNOTATION_PREFIX}namespace": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}projectId": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}projectName": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}branch": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}commit-sha": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}username": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}default_image_used": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}repository": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}git-host": "smth",
+    f"{JUPYTERHUB_ANNOTATION_PREFIX}servername": "smth",
+    f"{JUPYTERHUB_ANNOTATION_PREFIX}username": "smth",
+}
+
+
+def test_unknown_annotations_allowed():
+    schema = UserPodAnnotations()
+    response = {
+        **passing_annotation_response,
+        "extra_annotation": "smth",
+    }
+    assert schema.load(response) == response
+
+
+def test_missing_required_annotation_fails():
+    schema = UserPodAnnotations()
+    response = passing_annotation_response.copy()
+    response.pop(f"{RENKU_ANNOTATION_PREFIX}projectName")
+    with pytest.raises(ValidationError):
+        schema.load(response)


### PR DESCRIPTION
So the schema validation for the annotations seems to be a bit too strict.

This will allow unknown annotations (not mentioned in the schema) to not trigger an error and to be included in the response.

It should fix this issue.
https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/5156/?environment=dslab2021renkulab&project=4&referrer=alert_email