### PR TITLE
fix: labels values are too long for k8s

### DIFF
--- a/cull_secrets/clean_user_registry_secrets.py
+++ b/cull_secrets/clean_user_registry_secrets.py
@@ -33,14 +33,13 @@ from kubernetes.config.incluster_config import (
 POD_LABELS = [  # unlikely to have invalid characters, used to quickly filter
     "renku.io/commit-sha",
     "renku.io/username",
-    "renku.io/projectName",
+    "renku.io/projectId",
 ]
 
 POD_ANNOTATIONS = [  # most likely to have invalid characters (i.e. /, \, etc)
     "renku.io/git-host",
     "renku.io/namespace",
     "renku.io/username",
-    "renku.io/projectName",
 ]
 
 

--- a/cull_secrets/clean_user_registry_secrets.py
+++ b/cull_secrets/clean_user_registry_secrets.py
@@ -33,7 +33,7 @@ from kubernetes.config.incluster_config import (
 POD_LABELS = [  # unlikely to have invalid characters, used to quickly filter
     "renku.io/commit-sha",
     "renku.io/username",
-    "renku.io/projectId",
+    "renku.io/gitlabProjectId",
 ]
 
 POD_ANNOTATIONS = [  # most likely to have invalid characters (i.e. /, \, etc)

--- a/cull_secrets/clean_user_registry_secrets.py
+++ b/cull_secrets/clean_user_registry_secrets.py
@@ -39,6 +39,8 @@ POD_LABELS = [  # unlikely to have invalid characters, used to quickly filter
 POD_ANNOTATIONS = [  # most likely to have invalid characters (i.e. /, \, etc)
     "renku.io/git-host",
     "renku.io/namespace",
+    "renku.io/username",
+    "renku.io/projectName",
 ]
 
 

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -308,7 +308,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         self.extra_annotations = {
             RENKU_ANNOTATION_PREFIX + "namespace": options.get("namespace"),
             RENKU_ANNOTATION_PREFIX
-            + "projectId": "{}".format(options.get("project_id")),
+            + "gitlabProjectId": "{}".format(options.get("project_id")),
             RENKU_ANNOTATION_PREFIX + "branch": options.get("branch"),
             RENKU_ANNOTATION_PREFIX + "repository": repository_url,
             RENKU_ANNOTATION_PREFIX + "git-host": git_host,
@@ -318,10 +318,11 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         }
         # some annotations are repeated as labels so that the k8s api can filter resources
         self.extra_labels = {
-            RENKU_ANNOTATION_PREFIX + "username": safe_username[:63],
+            RENKU_ANNOTATION_PREFIX + "username": safe_username,
             RENKU_ANNOTATION_PREFIX + "commit-sha": options.get("commit_sha"),
             RENKU_ANNOTATION_PREFIX
-            + "projectId": "{}".format(options.get("project_id")),
+            + "gitlabProjectId": "{}".format(options.get("project_id")),
+            "hub.jupyter.org/network-access-hub": "true",
         }
 
         self.delete_grace_period = 30

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -320,8 +320,8 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         self.extra_labels = {
             RENKU_ANNOTATION_PREFIX + "username": safe_username[:63],
             RENKU_ANNOTATION_PREFIX + "commit-sha": options.get("commit_sha"),
-            RENKU_ANNOTATION_PREFIX + "projectName": options.get("project")[:63],
-            "hub.jupyter.org/network-access-hub": "true"
+            RENKU_ANNOTATION_PREFIX
+            + "projectId": "{}".format(options.get("project_id")),
         }
 
         self.delete_grace_period = 30

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -318,9 +318,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         }
         # some annotations are repeated as labels so that the k8s api can filter resources
         self.extra_labels = {
-            RENKU_ANNOTATION_PREFIX + "username": safe_username,
+            RENKU_ANNOTATION_PREFIX + "username": safe_username[:63],
             RENKU_ANNOTATION_PREFIX + "commit-sha": options.get("commit_sha"),
-            RENKU_ANNOTATION_PREFIX + "projectName": options.get("project"),
+            RENKU_ANNOTATION_PREFIX + "projectName": options.get("project")[:63],
             "hub.jupyter.org/network-access-hub": "true"
         }
 

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -229,7 +229,7 @@ def launch_notebook(
         safe_username = escapism.escape(user.get("name"), escape_char="-").lower()
         secret_name = f"{safe_username}-registry-{str(uuid4())}"
         create_registry_secret(
-            user, namespace, secret_name, project, commit_sha, git_host
+            user, namespace, secret_name, gl_project.id, commit_sha, git_host
         )
         payload["image_pull_secrets"] = [secret_name]
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -82,7 +82,9 @@ class UserPodAnnotations(
     Schema.from_dict(
         {
             f"{config.RENKU_ANNOTATION_PREFIX}namespace": fields.Str(required=True),
-            f"{config.RENKU_ANNOTATION_PREFIX}projectId": fields.Str(required=True),
+            f"{config.RENKU_ANNOTATION_PREFIX}gitlabProjectId": fields.Str(
+                required=False
+            ),
             f"{config.RENKU_ANNOTATION_PREFIX}projectName": fields.Str(required=True),
             f"{config.RENKU_ANNOTATION_PREFIX}branch": fields.Str(required=True),
             f"{config.RENKU_ANNOTATION_PREFIX}commit-sha": fields.Str(required=True),

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -272,11 +272,11 @@ def create_registry_secret(
             "labels": {
                 "component": "singleuser-server",
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "username": safe_username[:63],
+                + "username": safe_username,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "commit-sha": commit_sha,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "projectId": str(project_id),
+                + "gitlabProjectId": str(project_id),
             },
         },
         type="kubernetes.io/dockerconfigjson",

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -276,7 +276,7 @@ def create_registry_secret(
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "commit-sha": commit_sha,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "projectId": project_id,
+                + "projectId": str(project_id),
             },
         },
         type="kubernetes.io/dockerconfigjson",

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -231,7 +231,9 @@ def read_namespaced_pod_log(pod_name, max_log_lines=0, container_name="notebook"
     return logs
 
 
-def create_registry_secret(user, namespace, secret_name, project, commit_sha, git_host):
+def create_registry_secret(
+    user, namespace, secret_name, project_id, commit_sha, git_host
+):
     """Create a registry secret for a user."""
     import base64
     import json
@@ -266,8 +268,6 @@ def create_registry_secret(user, namespace, secret_name, project, commit_sha, gi
                 + "namespace": namespace,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "username": safe_username,
-                current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "projectName": project,
             },
             "labels": {
                 "component": "singleuser-server",
@@ -276,7 +276,7 @@ def create_registry_secret(user, namespace, secret_name, project, commit_sha, gi
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "commit-sha": commit_sha,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "projectName": project[:63],
+                + "projectId": project_id,
             },
         },
         type="kubernetes.io/dockerconfigjson",

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -264,15 +264,19 @@ def create_registry_secret(user, namespace, secret_name, project, commit_sha, gi
                 + "git-host": git_host,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "namespace": namespace,
+                current_app.config.get("RENKU_ANNOTATION_PREFIX")
+                + "username": safe_username,
+                current_app.config.get("RENKU_ANNOTATION_PREFIX")
+                + "projectName": project,
             },
             "labels": {
                 "component": "singleuser-server",
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "username": safe_username,
+                + "username": safe_username[:63],
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
                 + "commit-sha": commit_sha,
                 current_app.config.get("RENKU_ANNOTATION_PREFIX")
-                + "projectName": project,
+                + "projectName": project[:63],
             },
         },
         type="kubernetes.io/dockerconfigjson",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,7 +249,7 @@ def kubernetes_client_full(mocker):
                             "renku.io/projectName": "dummyproject",
                             "renku.io/branch": "master",
                             "renku.io/default_image_used": "false",
-                            "renku.io/projectId": "42",
+                            "renku.io/gitlabProjectId": "42",
                             "renku.io/commit-sha": "0123456789",
                             "renku.io/repository": (
                                 "https://fakegitlab.renku.ch/dummynamespace/dummyproject"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,6 +266,7 @@ def kubernetes_client_full(mocker):
                             "renku.io/username": "dummyuser",
                             "renku.io/commit-sha": "0123456789",
                             "renku.io/namespace": "dummynamespace",
+                            "renku.io/projectName": "dummyproject",
                         },
                     },
                     "status": {

--- a/tests/test_clean_user_registry_secrets.py
+++ b/tests/test_clean_user_registry_secrets.py
@@ -47,7 +47,7 @@ def secret_list_valid():
                             "component": "singleuser-server",
                             "renku.io/commit-sha": "commit-sha",
                             "renku.io/username": "username",
-                            "renku.io/projectName": "project-name",
+                            "renku.io/projectId": "1",
                         },
                         "annotations": {
                             "renku.io/namespace": "namespace",
@@ -84,7 +84,7 @@ def secret_list_valid_new_secret():
                             "component": "singleuser-server",
                             "renku.io/commit-sha": "commit-sha",
                             "renku.io/username": "username",
-                            "renku.io/projectName": "project-name",
+                            "renku.io/projectId": "1",
                         },
                         "annotations": {
                             "renku.io/namespace": "namespace",
@@ -141,7 +141,7 @@ def pod_sample_valid():
                     "component": "singleuser-server",
                     "renku.io/commit-sha": "commit-sha",
                     "renku.io/username": "username",
-                    "renku.io/projectName": "project-name",
+                    "renku.io/projectId": "1",
                 },
                 "annotations": {
                     "renku.io/namespace": "namespace",
@@ -166,7 +166,7 @@ def pod_sample_pending():
                     "component": "singleuser-server",
                     "renku.io/commit-sha": "commit-sha",
                     "renku.io/username": "username",
-                    "renku.io/projectName": "project-name",
+                    "renku.io/projectId": "1",
                 },
                 "annotations": {
                     "renku.io/namespace": "namespace",

--- a/tests/test_clean_user_registry_secrets.py
+++ b/tests/test_clean_user_registry_secrets.py
@@ -52,6 +52,8 @@ def secret_list_valid():
                         "annotations": {
                             "renku.io/namespace": "namespace",
                             "renku.io/git-host": "git-host.com",
+                            "renku.io/username": "username",
+                            "renku.io/projectName": "project-name",
                         },
                     },
                 },
@@ -87,6 +89,8 @@ def secret_list_valid_new_secret():
                         "annotations": {
                             "renku.io/namespace": "namespace",
                             "renku.io/git-host": "git-host.com",
+                            "renku.io/username": "username",
+                            "renku.io/projectName": "project-name",
                         },
                     },
                 },
@@ -142,6 +146,8 @@ def pod_sample_valid():
                 "annotations": {
                     "renku.io/namespace": "namespace",
                     "renku.io/git-host": "git-host.com",
+                    "renku.io/username": "username",
+                    "renku.io/projectName": "project-name",
                 },
             },
             "status": {"phase": "Running"},
@@ -165,6 +171,8 @@ def pod_sample_pending():
                 "annotations": {
                     "renku.io/namespace": "namespace",
                     "renku.io/git-host": "git-host.com",
+                    "renku.io/username": "username",
+                    "renku.io/projectName": "project-name",
                 },
             },
             "status": {"phase": "Pending"},

--- a/tests/test_clean_user_registry_secrets.py
+++ b/tests/test_clean_user_registry_secrets.py
@@ -47,7 +47,7 @@ def secret_list_valid():
                             "component": "singleuser-server",
                             "renku.io/commit-sha": "commit-sha",
                             "renku.io/username": "username",
-                            "renku.io/projectId": "1",
+                            "renku.io/gitlabProjectId": "1",
                         },
                         "annotations": {
                             "renku.io/namespace": "namespace",
@@ -84,7 +84,7 @@ def secret_list_valid_new_secret():
                             "component": "singleuser-server",
                             "renku.io/commit-sha": "commit-sha",
                             "renku.io/username": "username",
-                            "renku.io/projectId": "1",
+                            "renku.io/gitlabProjectId": "1",
                         },
                         "annotations": {
                             "renku.io/namespace": "namespace",
@@ -141,7 +141,7 @@ def pod_sample_valid():
                     "component": "singleuser-server",
                     "renku.io/commit-sha": "commit-sha",
                     "renku.io/username": "username",
-                    "renku.io/projectId": "1",
+                    "renku.io/gitlabProjectId": "1",
                 },
                 "annotations": {
                     "renku.io/namespace": "namespace",
@@ -166,7 +166,7 @@ def pod_sample_pending():
                     "component": "singleuser-server",
                     "renku.io/commit-sha": "commit-sha",
                     "renku.io/username": "username",
-                    "renku.io/projectId": "1",
+                    "renku.io/gitlabProjectId": "1",
                 },
                 "annotations": {
                     "renku.io/namespace": "namespace",

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -9,7 +9,7 @@ JUPYTERHUB_ANNOTATION_PREFIX = "hub.jupyter.org/"
 
 passing_annotation_response = {
     f"{RENKU_ANNOTATION_PREFIX}namespace": "smth",
-    f"{RENKU_ANNOTATION_PREFIX}projectId": "smth",
+    f"{RENKU_ANNOTATION_PREFIX}gitlabProjectId": "smth",
     f"{RENKU_ANNOTATION_PREFIX}projectName": "smth",
     f"{RENKU_ANNOTATION_PREFIX}branch": "smth",
     f"{RENKU_ANNOTATION_PREFIX}commit-sha": "smth",


### PR DESCRIPTION
So I think I came across something similar before but I noticed a bug on Friday through sentry ([link here](https://sentry.dev.renku.ch/organizations/swiss-datascience-center/issues/5210/?environment=renkulab&project=4&referrer=alert_email)) that is the result of a really long project name. We add the project name in the user pod labels but the labels in k8s cannot be longer than 63 characters so when someone with a long project name tries to launch a server it fails.

The way I resolved this is that in the labels I cut down the project name and username to a max of 63 characters. These are only used to filter the user pods when deleting the registry pull secrets. Then I also added the full project name and username in the pod annotations - which have no length limit. The annotations are then used to further filter the pods (that have already been filtered by the k8s api with the labels) when deleting old secrets and it ensures that there are no collisions because of the truncation in the labels.

This is deployed on https://tasko.dev.renku.ch/. I also tested with a project name that is 70 characters long and it works.

I did the acceptance tests locally and they passed after I increased the time for which the tests wait after deleting a project (in order to confirm the project was really deleted). The code here does not affect the deletion of a project at all - for some reason it is taking a bit longer than usual for the project to disappear from the UI after it is deleted in GitLab.