### PR TITLE
fix: increase huboauth caching from 1min to 5min

### DIFF
--- a/renku_notebooks/config.py
+++ b/renku_notebooks/config.py
@@ -33,7 +33,7 @@ JUPYTERHUB_API_TOKEN = os.environ.get("JUPYTERHUB_API_TOKEN", "")
 """The service api token."""
 
 JUPYTERHUB_ADMIN_AUTH = HubOAuth(
-    api_token=os.environ.get("JUPYTERHUB_API_TOKEN", "token"), cache_max_age=60
+    api_token=os.environ.get("JUPYTERHUB_API_TOKEN", "token"), cache_max_age=300
 )
 """The oauth object used to query the JH API as an admin to get user information."""
 


### PR DESCRIPTION
According to profiles run on the /servers endpoint, the execution time is mainly spent on two functions in the user class code: `_get_hub_username` and `_get_hub_user`. The _get_hub_username function just uses the `user_for_token` method of HubOAuth from jupyterhub. And if we adjust the caching that is provided by jupyterhub in HubOAuth then we can save about ~150-300 ms. These are two profiles for the call to the same endpoint by the same user. I assume that in the second one the cache for HubOauth was used and the execution is roughly halved.

The default max cache age for HubOAuth from Jupyterhub is 300 sec (https://jupyterhub.readthedocs.io/en/stable/api/services.auth.html?highlight=huboauth#jupyterhub.services.auth.HubOAuth.cache_max_age)

Long execution time profile
![image](https://user-images.githubusercontent.com/16360283/114534376-3b873c00-9c4f-11eb-8aeb-3f29a5ec164e.png)

Short execution time profile
![image](https://user-images.githubusercontent.com/16360283/114534466-4e9a0c00-9c4f-11eb-9744-e1c227db9274.png)
