### PR TITLE
fix: unset lfs auth mode in init container

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
         RENKU_RELEASE: renku-ci-nb-${{ github.event.number }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > ${{ github.workspace }}/renkubot-kube.config
-        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 40m --logs
+        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
       uses: SwissDataScienceCenter/renku/actions/download-test-artifacts@master

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -96,7 +96,7 @@ git config http.proxy http://localhost:8080
 git config http.sslVerify false
 git config --unset credential.helper
 rm .git/credentials
-git config --unset lfs.${REPOSITORY}/info/lfs.access
+git config --unset lfs.${REPOSITORY}/info/lfs.access || true
 
 # Finally, set the correct permissions for the main container.
 chown ${USER_ID}:${GROUP_ID} -Rc ${MOUNT_PATH}

--- a/git-clone/entrypoint.sh
+++ b/git-clone/entrypoint.sh
@@ -96,6 +96,7 @@ git config http.proxy http://localhost:8080
 git config http.sslVerify false
 git config --unset credential.helper
 rm .git/credentials
+git config --unset lfs.${REPOSITORY}/info/lfs.access
 
 # Finally, set the correct permissions for the main container.
 chown ${USER_ID}:${GROUP_ID} -Rc ${MOUNT_PATH}


### PR DESCRIPTION
This PR fixes a problem which occurrs when two conditions were met simultaneously:

1. The git lfs auto fetch option is set to true on session start
2. There are files in LFS.

In this case, git lfs adds a line like `lfs.https://renkulab.io/gitlab/andreas/test-lfs-problem.git/info/lfs.access=basic` to the repos `.git/config` when pulling the files during the init container. Because of this configuration, git prompts for username and password later when a user tries to push from the main session container. Removing this config at the end of the init container entry point delegates authentication back to the git http proxy.

/deploy