### PR TITLE
feat: endpoint for autosave information

### DIFF
--- a/renku_notebooks/__init__.py
+++ b/renku_notebooks/__init__.py
@@ -33,6 +33,7 @@ from .api.notebooks import (
     stop_server,
     server_options,
     server_logs,
+    autosave_info,
 )
 from .api.auth import bp as auth_bp, whoami
 
@@ -146,5 +147,6 @@ def register_swagger(app):
     docs.register(stop_server, blueprint=notebooks_bp.name)
     docs.register(server_options, blueprint=notebooks_bp.name)
     docs.register(server_logs, blueprint=notebooks_bp.name)
+    docs.register(autosave_info, blueprint=notebooks_bp.name)
     docs.register(whoami, blueprint=auth_bp.name)
     return app

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -512,4 +512,4 @@ class UserServer:
     @property
     def _pvc_name(self):
         """Form a PVC name from a username and servername."""
-        return f"{self.safe_username}-{self.namespace}-{self.server_name}-pvc"
+        return f"{self.server_name}-pvc"

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -97,7 +97,10 @@ class User:
             for project in projects:
                 for branch in project.branches.list():
                     if re.match(r"^renku\/autosave\/", branch.name) is not None:
-                        autosaves.append(branch)
+                        autosaves.append({
+                            "branch": branch,
+                            "root_commit": project.commits.get(branch.name.split("/")[-1]).id
+                        })
             return autosaves
 
     def _get_pvcs(self):

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -81,8 +81,7 @@ class User:
             else:
                 project_name_annotation_key = current_app.config.get(
                     "RENKU_ANNOTATION_PREFIX"
-                )
-                +"projectName"
+                ) + "projectName"
                 return [
                     pvc
                     for pvc in self._get_pvcs()

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -91,7 +91,7 @@ class User:
         else:
             autosaves = []
             if namespace_project is None:  # get autosave branches from all projects
-                projects = self.projects.list()
+                projects = self.gitlab_client.projects.list()
             else:
                 projects = [self.get_renku_project(namespace_project)]
             for project in projects:

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -117,7 +117,7 @@ class User:
             try:
                 return k8s_client.list_namespaced_persistent_volume_claim(
                     k8s_namespace, label_selector=label_selector
-                )
+                ).items
             except client.ApiException:
                 return []
 

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -80,9 +80,9 @@ class User:
             if namespace_project is None:
                 autosaves += self._get_pvcs()
             else:
-                project_name_annotation_key = current_app.config.get(
-                    "RENKU_ANNOTATION_PREFIX"
-                ) + "projectName"
+                project_name_annotation_key = (
+                    current_app.config.get("RENKU_ANNOTATION_PREFIX") + "projectName"
+                )
                 autosaves += [
                     pvc
                     for pvc in self._get_pvcs()
@@ -97,10 +97,14 @@ class User:
         for project in projects:
             for branch in project.branches.list():
                 if re.match(r"^renku\/autosave\/", branch.name) is not None:
-                    autosaves.append({
-                        "branch": branch,
-                        "root_commit": project.commits.get(branch.name.split("/")[-2]).id
-                    })
+                    autosaves.append(
+                        {
+                            "branch": branch,
+                            "root_commit": project.commits.get(
+                                branch.name.split("/")[-2]
+                            ).id,
+                        }
+                    )
         return autosaves
 
     def _get_pvcs(self):

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -75,33 +75,33 @@ class User:
     def get_autosaves(self, namespace_project=None):
         """Get a list of autosaves for all projects for the user"""
         autosaves = []
+        # add pvcs to list of autosaves only if pvcs are supported in deployment
         if current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"]:
             if namespace_project is None:
-                return self._get_pvcs()
+                autosaves += self._get_pvcs()
             else:
                 project_name_annotation_key = current_app.config.get(
                     "RENKU_ANNOTATION_PREFIX"
                 ) + "projectName"
-                return [
+                autosaves += [
                     pvc
                     for pvc in self._get_pvcs()
                     if pvc.metadata.annotations.get(project_name_annotation_key)
                     == namespace_project.split("/")[-1]
                 ]
+        # add any autosave branches, regardless of wheter pvcs are supported or not
+        if namespace_project is None:  # get autosave branches from all projects
+            projects = self.gitlab_client.projects.list()
         else:
-            autosaves = []
-            if namespace_project is None:  # get autosave branches from all projects
-                projects = self.gitlab_client.projects.list()
-            else:
-                projects = [self.get_renku_project(namespace_project)]
-            for project in projects:
-                for branch in project.branches.list():
-                    if re.match(r"^renku\/autosave\/", branch.name) is not None:
-                        autosaves.append({
-                            "branch": branch,
-                            "root_commit": project.commits.get(branch.name.split("/")[-1]).id
-                        })
-            return autosaves
+            projects = [self.get_renku_project(namespace_project)]
+        for project in projects:
+            for branch in project.branches.list():
+                if re.match(r"^renku\/autosave\/", branch.name) is not None:
+                    autosaves.append({
+                        "branch": branch,
+                        "root_commit": project.commits.get(branch.name.split("/")[-2]).id
+                    })
+        return autosaves
 
     def _get_pvcs(self):
         """Get all session pvcs that belong to this user"""

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -256,4 +256,7 @@ def server_logs(user, server_name):
 @authenticated
 def autosave_info(user, namespace_group, project):
     """Information about all autosaves for a project."""
-    return user.get_autosaves(f"{namespace_group}/{project}")
+    return {
+        "pvsSupport": current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"],
+        "autosaves": user.get_autosaves(f"{namespace_group}/{project}")
+    }

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -250,13 +250,21 @@ def server_logs(user, server_name):
     summary="Information about autosaved and recovered work from user sessions.",
     responses={
         200: {"description": "All the autosave branches or PVs for the project."},
+        404: {"description": "The requested project and/or namespace cannot be found."},
     },
 )
 @marshal_with(AutosavesList(), code=200, description="List of autosaves.")
 @authenticated
 def autosave_info(user, namespace_group, project):
     """Information about all autosaves for a project."""
+    if user.get_renku_project(f"{namespace_group}/{project}") is None:
+        return make_response(jsonify({
+            "messages": {
+                "error": f"Cannot find project {namespace_group}/{project}"
+            }}),
+            404,
+        )
     return {
         "pvsSupport": current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"],
-        "autosaves": user.get_autosaves(f"{namespace_group}/{project}")
+        "autosaves": user.get_autosaves(f"{namespace_group}/{project}"),
     }

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -33,6 +33,7 @@ from .schemas import (
     ServerLogs,
     ServerOptions,
     FailedParsing,
+    AutosavesList,
 )
 from ..util.misc import read_server_options_file
 from .classes.server import UserServer
@@ -241,3 +242,18 @@ def server_logs(user, server_name):
         if logs is not None:
             return {"items": str.splitlines(logs)}, 200
     return make_response(jsonify({"messages": {"error": "Cannot find server"}}), 404)
+
+
+@bp.route("autosave/<path:namespace_group>/<string:project>")
+@doc(
+    tags=["autosave"],
+    summary="Information about autosaved and recovered work from user sessions.",
+    responses={
+        200: {"description": "All the autosave branches or PVs for the project."},
+    },
+)
+@marshal_with(AutosavesList(), code=200, description="List of autosaves.")
+@authenticated
+def autosave_info(user, namespace_group, project):
+    """Information about all autosaves for a project."""
+    return user.get_autosaves(f"{namespace_group}/{project}")

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -258,10 +258,14 @@ def server_logs(user, server_name):
 def autosave_info(user, namespace_group, project):
     """Information about all autosaves for a project."""
     if user.get_renku_project(f"{namespace_group}/{project}") is None:
-        return make_response(jsonify({
-            "messages": {
-                "error": f"Cannot find project {namespace_group}/{project}"
-            }}),
+        return make_response(
+            jsonify(
+                {
+                    "messages": {
+                        "error": f"Cannot find project {namespace_group}/{project}"
+                    }
+                }
+            ),
             404,
         )
     return {

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -497,7 +497,9 @@ class AutosavesItem(Schema):
                 "branch": autosave["branch"].name.split("/")[3],
                 "commit": autosave["root_commit"],
                 "pvs": False,
-                "date": datetime.fromisoformat(autosave["branch"].commit["committed_date"]),
+                "date": datetime.fromisoformat(
+                    autosave["branch"].commit["committed_date"]
+                ),
             }
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flask import current_app
 from marshmallow import (
     Schema,
@@ -487,14 +488,14 @@ class AutosavesItem(Schema):
                     current_app.config.get("RENKU_ANNOTATION_PREFIX") + "commit-sha"
                 ),
                 "pvs": True,
-                "date": autosave.metadata.creation_timestamp,
+                "date": datetime.fromisoformat(autosave.metadata.creation_timestamp),
             }
         else:  # autosave is a gitlab branch
             return {
                 "branch": autosave.name,
                 "commit": autosave.commit["id"],
                 "pvs": False,
-                "date": autosave.commit["committed_date"],
+                "date": datetime.fromisoformat(autosave.commit["committed_date"]),
             }
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -480,6 +480,7 @@ class AutosavesItem(Schema):
     @pre_dump
     def extract_data(self, autosave, *args, **kwargs):
         if type(autosave) is V1PersistentVolumeClaim:
+            # autosave is a pvc
             return {
                 "branch": autosave.metadata.annotations.get(
                     current_app.config.get("RENKU_ANNOTATION_PREFIX") + "branch"
@@ -490,9 +491,10 @@ class AutosavesItem(Schema):
                 "pvs": True,
                 "date": autosave.metadata.creation_timestamp,
             }
-        else:  # autosave is a gitlab branch
+        else:
+            # autosave is a dictionary with root commit and gitlab branch
             return {
-                "branch": autosave["branch"].name,
+                "branch": autosave["branch"].name.split("/")[3],
                 "commit": autosave["root_commit"],
                 "pvs": False,
                 "date": datetime.fromisoformat(autosave["branch"].commit["committed_date"]),

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -492,10 +492,10 @@ class AutosavesItem(Schema):
             }
         else:  # autosave is a gitlab branch
             return {
-                "branch": autosave.name,
-                "commit": autosave.commit["id"],
+                "branch": autosave["branch"].name,
+                "commit": autosave["root_commit"],
                 "pvs": False,
-                "date": datetime.fromisoformat(autosave.commit["committed_date"]),
+                "date": datetime.fromisoformat(autosave["branch"].commit["committed_date"]),
             }
 
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -488,7 +488,7 @@ class AutosavesItem(Schema):
                     current_app.config.get("RENKU_ANNOTATION_PREFIX") + "commit-sha"
                 ),
                 "pvs": True,
-                "date": datetime.fromisoformat(autosave.metadata.creation_timestamp),
+                "date": autosave.metadata.creation_timestamp,
             }
         else:  # autosave is a gitlab branch
             return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,17 @@ class _AttributeDictionary(dict):
             self[key] = value
 
 
+class CustomList:
+    def __init__(self, *args):
+        self.__objects = list(args)
+
+    def list(self):
+        return self.__objects
+
+    def items(self):
+        return self.__objects
+
+
 @pytest.fixture(
     params=[
         (
@@ -170,16 +181,6 @@ def gitlab(request, mocker):
     def create_mock_gitlab_project(
         access_level, namespace="dummynamespace", project_name="dummyproject"
     ):
-        class List:
-            def __init__(self, *args):
-                self.__objects = list(args)
-
-            def list(self):
-                return self.__objects
-
-            def items(self):
-                return self.__objects
-
         gitlab_project = _AttributeDictionary(
             {
                 f"{namespace}/{project_name}": {
@@ -187,16 +188,16 @@ def gitlab(request, mocker):
                     "visibility": "public",
                     "path_with_namespace": f"{namespace}/{project_name}",
                     "attributes": {
-                        "permissions": List([{}, {"access_level": access_level}]),
+                        "permissions": CustomList([{}, {"access_level": access_level}]),
                         "id": 42,
                         "visibility": "public",
                         "path_with_namespace": f"{namespace}/{project_name}",
                     },
-                    "pipelines": List(
+                    "pipelines": CustomList(
                         _AttributeDictionary(
                             {
                                 "attributes": {"sha": ""},
-                                "jobs": List(
+                                "jobs": CustomList(
                                     _AttributeDictionary(
                                         {"attributes": {"name": "", "status": ""}}
                                     )
@@ -204,7 +205,7 @@ def gitlab(request, mocker):
                             }
                         )
                     ),
-                    "repositories": List(
+                    "repositories": CustomList(
                         _AttributeDictionary(
                             {
                                 "attributes": {

--- a/tests/test_autosaves.py
+++ b/tests/test_autosaves.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Autosaves of the Notebook Services API"""
+from datetime import datetime
+import pytest
+from kubernetes.client import V1PersistentVolumeClaim, V1ObjectMeta
+from unittest.mock import patch
+
+from renku_notebooks.api import config
+from tests.conftest import _AttributeDictionary, CustomList
+
+AUTHORIZED_HEADERS = {"Authorization": "token 8f7e09b3bf6b8a20"}
+
+
+def dict_from_object(obj):
+    # taken from code for config.from_object in flask
+    output = {}
+    for key in dir(obj):
+        if key.isupper():
+            output[key] = getattr(obj, key)
+    return output
+
+
+@pytest.fixture
+def setup_pvcs(mocker):
+    def _setup_pvcs(project, branches, commits, commited_datetime):
+        mocker.patch("renku_notebooks.api.classes.user.User._get_pvcs").return_value = [
+            V1PersistentVolumeClaim(
+                metadata=V1ObjectMeta(
+                    annotations={
+                        config.RENKU_ANNOTATION_PREFIX + "projectName": project,
+                        config.RENKU_ANNOTATION_PREFIX + "branch": branches[i],
+                        config.RENKU_ANNOTATION_PREFIX + "commit-sha": commits[i],
+                    },
+                    creation_timestamp=commited_datetime,
+                ),
+            )
+            for i in range(len(branches))
+        ]
+
+    yield _setup_pvcs
+
+
+@pytest.fixture
+def setup_project(mocker):
+    def _setup_project(branches, commits, date_isostring):
+        mocker.patch(
+            "renku_notebooks.api.classes.user.User.get_renku_project"
+        ).return_value = _AttributeDictionary(
+            {
+                "commits": _AttributeDictionary(
+                    {commit: _AttributeDictionary({"id": commit}) for commit in commits}
+                ),
+                "branches": CustomList(
+                    *[
+                        _AttributeDictionary(
+                            {
+                                "name": branch,
+                                "commit": _AttributeDictionary(
+                                    {"committed_date": date_isostring}
+                                ),
+                            }
+                        )
+                        for branch in branches
+                    ],
+                ),
+            }
+        )
+
+    yield _setup_project
+
+
+@pytest.fixture
+def patch_config(mocker):
+    def _patch_config(props_to_override):
+        mock_config = _AttributeDictionary(
+            {**dict_from_object(config), **props_to_override}
+        )
+        mocker.patch(
+            "renku_notebooks.api.classes.user.current_app"
+        ).config = mock_config
+        mocker.patch("renku_notebooks.api.notebooks.current_app").config = mock_config
+
+    yield _patch_config
+
+
+def test_autosaves_only_pvs(setup_pvcs, setup_project, patch_config, client):
+    tstamp = datetime(2020, 1, 1, 1)
+    patch_config({"NOTEBOOKS_SESSION_PVS_ENABLED": True})
+    setup_project(
+        ["master", "branch1"], ["123243534", "425236526542"], tstamp.isoformat()
+    )
+    setup_pvcs("project", ["branch1"], ["1235435"], tstamp)
+    response = client.get(
+        "/service/autosave/namespace/project", headers=AUTHORIZED_HEADERS
+    )
+    assert response.status_code == 200
+    assert response.json == {
+        "autosaves": [
+            {
+                "branch": "branch1",
+                "commit": "1235435",
+                "date": tstamp.isoformat(),
+                "pvs": True,
+            }
+        ],
+        "pvsSupport": True,
+    }
+
+
+def test_autosaves_branches_pvs(setup_pvcs, setup_project, patch_config, client):
+    tstamp = datetime(2020, 1, 1, 1)
+    patch_config({"NOTEBOOKS_SESSION_PVS_ENABLED": True})
+    setup_project(
+        ["master", "branch1", "renku/autosave/username/branch2/11111111/22222222"],
+        ["123243534", "425236526542", "9999999", "11111111", "22222222"],
+        tstamp.isoformat(),
+    )
+    setup_pvcs("project", ["branch1"], ["1235435"], tstamp)
+    response = client.get(
+        "/service/autosave/namespace/project", headers=AUTHORIZED_HEADERS
+    )
+    assert response.status_code == 200
+    assert response.json == {
+        "autosaves": [
+            {
+                "branch": "branch1",
+                "commit": "1235435",
+                "date": tstamp.isoformat(),
+                "pvs": True,
+            },
+            {
+                "branch": "branch2",
+                "commit": "11111111",
+                "date": tstamp.isoformat(),
+                "pvs": False,
+            },
+        ],
+        "pvsSupport": True,
+    }
+
+
+def test_autosaves_only_branches(setup_pvcs, setup_project, patch_config, client):
+    tstamp = datetime(2020, 1, 1, 1)
+    patch_config({"NOTEBOOKS_SESSION_PVS_ENABLED": False})
+    setup_project(
+        ["master", "branch1", "renku/autosave/username/branch2/11111111/22222222"],
+        ["123243534", "425236526542", "9999999", "11111111", "22222222"],
+        tstamp.isoformat(),
+    )
+    setup_pvcs("project", ["branch1"], ["1235435"], tstamp)
+    response = client.get(
+        "/service/autosave/namespace/project", headers=AUTHORIZED_HEADERS
+    )
+    assert response.status_code == 200
+    assert response.json == {
+        "autosaves": [
+            {
+                "branch": "branch2",
+                "commit": "11111111",
+                "date": tstamp.isoformat(),
+                "pvs": False,
+            },
+        ],
+        "pvsSupport": False,
+    }
+
+
+def test_autosaves_no_pvs(setup_pvcs, setup_project, patch_config, client):
+    tstamp = datetime(2020, 1, 1, 1)
+    patch_config({"NOTEBOOKS_SESSION_PVS_ENABLED": True})
+    setup_project(
+        ["master", "branch1"],
+        ["123243534", "425236526542", "9999999", "11111111", "22222222"],
+        tstamp.isoformat(),
+    )
+    setup_pvcs("project", [], [], tstamp)
+    response = client.get(
+        "/service/autosave/namespace/project", headers=AUTHORIZED_HEADERS
+    )
+    assert response.status_code == 200
+    assert response.json == {
+        "autosaves": [],
+        "pvsSupport": True,
+    }
+
+
+@patch("renku_notebooks.api.classes.user.User.get_renku_project")
+def test_autosaves_non_existing_project(get_renku_project, client):
+    get_renku_project.return_value = None
+    response = client.get(
+        "/service/autosave/namespace/wrong_project", headers=AUTHORIZED_HEADERS
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
closes #584 

Made according to the swagger spec that @lorenzo-cavazzi specified [here](https://app.swaggerhub.com/apis/lorenzo-cavazzi/renku-notebooks/0.1.0)

Example output:
```json
{
  "autosaves": [
    {
      "branch": "master",
      "commit": "993875e950de66a1074d58cb8ce89b54f41a0941",
      "date": "2021-03-08T16:04:08+00:00",
      "pvs": false
    }
  ],
  "pvsSupport": true
}
```

/deploy