### PR TITLE
fix: add missing CHART_NAME var in ci image publishing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        CHART_NAME: renku-notebooks
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version


### PR DESCRIPTION
It seems this variable is required in several steps and is missing from one causing a new chart to not get published and fail.

See: https://github.com/SwissDataScienceCenter/renku-notebooks/runs/2418393909