### PR TITLE
fix: missing annotations handling in marshmallow

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -130,10 +130,10 @@ class UserPodAnnotations(
     class Meta:
         unknown = INCLUDE
 
-    def get_attribute(self, obj, key, *args, **kwargs):
+    def get_attribute(self, obj, key, default, *args, **kwargs):
         # in marshmallow, any schema key with a dot in it is converted to nested dictionaries
         # in marshmallow, this overrides that behaviour for dumping (serializing)
-        return obj[key]
+        return obj.get(key, default)
 
     @post_load
     def unnest_keys(self, data, **kwargs):


### PR DESCRIPTION
This fixes a bug that resulted when an old session pod with some missing annotations was encountered. The bug happened in marshmallow and it resulted because annotations have `.` characters in their keys but marshmallow automatically converts keys like that in nested dictionaries. To bypass that the schemas that work with annotations had to be customized and some of the default marshmallow schema class methods had to be overridden. This overriding was not done properly and the overridden method was not taking into account missing/default keys and erroring out.

This fixes this problem.

I spun up a session in my deployment to test this. Having a pod with the annotations that are not marked as `required` in the marshmallow schema (such as `git-host`) does not cause the bug now. Also tested that having secrets without these annotations are not deleted but also do not crash the secret culling cronjob.

Currently deployed at https://tasko.dev.renku.ch/