### PR TITLE
chore: update changelog for 0.8.12 release

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.action != 'closed'
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.3.2
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   check-deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for renku-notebooks
 
 ## [0.8.12](https://github.com/SwissDataScienceCenter/renku-notebooks/compare/0.8.11...0.8.12) (2021-04-16)
+
+### Bug Fixes
+
+* **app:** missing annotations handling in marshmallow ([23e54b0](https://github.com/SwissDataScienceCenter/renku-notebooks/commit/23e54b06620b341000fde4b7f5917284e8a17bf0))
+
 ### Features
 
 * endpoint for autosave information ([#607](https://github.com/SwissDataScienceCenter/renku-notebooks/issues/607)) ([5370a13](https://github.com/SwissDataScienceCenter/renku-notebooks/commit/5370a13))


### PR DESCRIPTION
This should be merged before the 0.8.12 release of notebooks is finalized.