### PR TITLE
fix: remove disk request values

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -79,12 +79,12 @@ serverOptions:
   #   type: int
   #   default: 0
   #   range: [0, 0]
-  disk_request:
-    order: 4
-    displayName: Amount of disk space requested
-    type: enum
-    default: "1G"
-    options: ["1G", "10G"]
+  # disk_request:
+  #   order: 4
+  #   displayName: Amount of disk space requested
+  #   type: enum
+  #   default: "1G"
+  #   options: ["1G", "10G"]
     ## set allow_any_value to true to not enforce value checks
     ## arbitrary PV sizes
     # allow_any_value: true

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -248,7 +248,7 @@ class UserServer:
         if current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"]:
             pvc_exists = self.get_pvc() is not None
             self._create_pvc(
-                storage_size=self.server_options.get("disk_request"),
+                storage_size=self.server_options.get("disk_request", "2G"),
                 storage_class=current_app.config["NOTEBOOKS_SESSION_PVS_STORAGE_CLASS"],
             )
             payload["pvc_name"] = self._pvc_name


### PR DESCRIPTION
This removes the disk request values from showing up by default.

Also it addresses the separate issue of the notebook sessions not launching when the PVCs for user sessions are enabled but the disk request values are not shown in the UI.

#649 will properly address the multiple edge cases of what server options are used by default in which cases. This is just a quick fix to make sure the disk requests do not show up always and that if someone is using PVCs they will still be able to do things.