### PR TITLE
chore: tag notebook images with latest when tagging a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,12 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     - name: Push latest image
       env:
-        CHART_NAME: renku-notebooks
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
-        if [ -z "$CHART_DIR" ]; then
-          CHART_DIR="helm-chart/"
-        fi
-        if [ ! -z "$IMAGE_PREFIX" ]; then
-          IMAGE_PREFIX="--image-prefix ${IMAGE_PREFIX}"
-        fi
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
-        helm dep update $CHART_DIR/$CHART_NAME
-        chartpress --push --tag latest $IMAGE_PREFIX
+        helm dep update helm-chart/renku-notebooks
+        chartpress --push --tag latest
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,28 @@ jobs:
       run: |
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
         echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
-    - name: Push chart and images
+    - name: Push tagged chart and images
       uses: SwissDataScienceCenter/renku/actions/publish-chart@0.7.11
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Push latest image
+      env:
+        CHART_NAME: renku-notebooks
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        if [ -z "$CHART_DIR" ]; then
+          CHART_DIR="helm-chart/"
+        fi
+        if [ ! -z "$IMAGE_PREFIX" ]; then
+          IMAGE_PREFIX="--image-prefix ${IMAGE_PREFIX}"
+        fi
+        echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+        helm dep update $CHART_DIR/$CHART_NAME
+        chartpress --push --tag latest $IMAGE_PREFIX
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@fix-update-component-action-chartpress-installation
+      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,19 +65,12 @@ jobs:
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
         echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
     - name: Push tagged chart and images
-      uses: SwissDataScienceCenter/renku/actions/publish-chart@0.7.11
+      uses: SwissDataScienceCenter/renku/actions/publish-chart@master
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Wait for chart to get published
-      run: sleep 120
-    - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@0.7.11
-      env:
-        CHART_NAME: renku-notebooks
-        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
     - name: Push latest image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -86,3 +79,10 @@ jobs:
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
         chartpress --push --tag test-latest
+    - name: Wait for chart to get published
+      run: sleep 120
+    - name: Update component version
+      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
+      env:
+        CHART_NAME: renku-notebooks
+        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,4 @@ jobs:
         pipenv install --dev
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
-        pipenv run chartpress --push --tag test-latest
+        pipenv run chartpress --push --tag latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           pipenv install --deploy --system --dev
           chartpress
 
-  publish-chart:
+  publish-chart-tagged:
     runs-on: ubuntu-latest
     needs: test-chart
     if: "startsWith(github.ref, 'refs/tags/')"
@@ -71,15 +71,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Push latest image
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: |
-        rm -rf helm-chart/renku-notebooks/tmpcharts
-        echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
-        helm dep update helm-chart/renku-notebooks
-        chartpress --push --tag test-latest
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version
@@ -87,3 +78,20 @@ jobs:
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+
+  publish-chart-latest:
+    runs-on: ubuntu-latest
+    needs: publish-chart-tagged
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Push latest image
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+        helm dep update helm-chart/renku-notebooks
+        chartpress --push --tag test-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
-        chartpress --push --tag latest
+        chartpress --push --tag test-latest
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
 
-  publish-latest-image:
+  push-latest-image:
     runs-on: ubuntu-latest
     needs: publish-chart-tagged
     if: "startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
+        rm -rf helm-chart/renku-notebooks/tmpcharts
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
         chartpress --push --tag test-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
+      uses: SwissDataScienceCenter/renku/actions/update-component-version@fix-update-component-action-chartpress-installation
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
 
-  publish-chart-latest:
+  publish-latest-image:
     runs-on: ubuntu-latest
     needs: publish-chart-tagged
     if: "startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Wait for chart to get published
+      run: sleep 120
+    - name: Update component version
+      uses: SwissDataScienceCenter/renku/actions/update-component-version@0.7.11
+      env:
+        CHART_NAME: renku-notebooks
+        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
     - name: Push latest image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -79,10 +86,3 @@ jobs:
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
         chartpress --push --tag test-latest
-    - name: Wait for chart to get published
-      run: sleep 120
-    - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@0.7.11
-      env:
-        CHART_NAME: renku-notebooks
-        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,19 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     steps:
     - uses: actions/checkout@v2
+    - uses: azure/setup-helm@v1
+    - uses: actions/setup-python@v2
       with:
-        fetch-depth: 0
+        python-version: 3.7
     - name: Push latest image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
+        pip install --user pipx
+        pipx ensurepath
+        pipx install pipenv
+        pipenv install --dev
         echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
         helm dep update helm-chart/renku-notebooks
-        chartpress --push --tag test-latest
+        pipenv run chartpress --push --tag test-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
         echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
     - name: Push tagged chart and images
-      uses: SwissDataScienceCenter/renku/actions/publish-chart@master
+      uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.1.0
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
     - name: Wait for chart to get published
       run: sleep 120
     - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
+      uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.1.0
       env:
         CHART_NAME: renku-notebooks
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
It seems that the notebook images are not tagged with latest at all. This should correct that. Now whenever images are tagged with a release tag the same images will also be published with the `latest` tag as well.

Here is the passing workflow for testing this: https://github.com/SwissDataScienceCenter/renku-notebooks/actions/runs/982073584