### PR TITLE
fix: properly display storage

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -73,18 +73,12 @@ serverOptions:
     type: enum
     default: 1G
     options: [1G, 2G]
-  # Int values are also supported
-  # gpu_request:
-  #   displayName: Number of GPUs
-  #   type: int
-  #   default: 0
-  #   range: [0, 0]
-  # disk_request:
-  #   order: 4
-  #   displayName: Amount of disk space requested
-  #   type: enum
-  #   default: "1G"
-  #   options: ["1G", "10G"]
+  disk_request:
+    order: 4
+    displayName: Amount of storage
+    type: enum
+    default: "1G"
+    options: ["1G"]
     ## set allow_any_value to true to not enforce value checks
     ## arbitrary PV sizes
     # allow_any_value: true

--- a/renku_notebooks/api/classes/storage.py
+++ b/renku_notebooks/api/classes/storage.py
@@ -6,7 +6,7 @@ import requests
 import re
 from urllib.parse import urlparse
 
-from ...util.kubernetes_ import get_k8s_client, make_server_name
+from ...util.kubernetes_ import get_k8s_client, make_pvc_name
 from ...util.file_size import parse_file_size
 
 
@@ -123,14 +123,12 @@ class SessionPVC(Autosave):
         k8s_client, k8s_namespace = get_k8s_client()
         self.k8s_client = k8s_client
         self.k8s_namespace = k8s_namespace
-        self.name = (
-            make_server_name(
-                self.namespace,
-                self.project,
-                self.root_branch_name,
-                self.root_commit_sha,
-            )
-            + "-pvc"
+        self.name = make_pvc_name(
+            self.user.safe_username,
+            self.namespace,
+            self.project,
+            self.root_branch_name,
+            self.root_commit_sha,
         )
         self.creation_date = (
             None if not self.exists else self.pvc.metadata.creation_timestamp

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -100,3 +100,13 @@ def make_server_name(namespace, project, branch, commit_sha):
     return "{project}-{hash}".format(
         project=project[:54], hash=md5(server_string.encode()).hexdigest()[:8]
     )
+
+
+def make_pvc_name(safe_username, namespace, project, branch, commit_sha):
+    """Form a 16-digit hash server ID."""
+    server_string = f"{safe_username}{namespace}{project}{branch}{commit_sha}"
+    return "{username}-{project}-{hash}".format(
+        username=safe_username[:10],
+        project=project[:44],
+        hash=md5(server_string.encode()).hexdigest()[:8],
+    )

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -103,7 +103,7 @@ def make_server_name(namespace, project, branch, commit_sha):
 
 
 def make_pvc_name(safe_username, namespace, project, branch, commit_sha):
-    """Form a 16-digit hash server ID."""
+    """Form a 16-digit hash persistent volume ID."""
     server_string = f"{safe_username}{namespace}{project}{branch}{commit_sha}"
     return "{username}-{project}-{hash}".format(
         username=safe_username[:10],

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -55,8 +55,8 @@ export JUPYTERHUB_SERVICE_PREFIX
 export JUPYTERHUB_URL
 export FLASK_APP=`pwd`/renku_notebooks/wsgi.py
 export FLASK_DEBUG=0
-export NOTEBOOKS_SERVER_OPTIONS_DEFAULTS_PATH=`pwd`/tests/dummy_server_options_defaults.json
-export NOTEBOOKS_SERVER_OPTIONS_UI_PATH=`pwd`/tests/dummy_server_options_ui.json
+export NOTEBOOKS_SERVER_OPTIONS_DEFAULTS_PATH=`pwd`/tests/dummy_server_defaults.json
+export NOTEBOOKS_SERVER_OPTIONS_UI_PATH=`pwd`/tests/dummy_server_options.json
 
 echo ""
 echo "================================================================================================================="

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ os.environ[
     "NOTEBOOKS_SERVER_OPTIONS_DEFAULTS_PATH"
 ] = "tests/dummy_server_defaults.json"
 os.environ["NOTEBOOKS_SERVER_OPTIONS_UI_PATH"] = "tests/dummy_server_options.json"
+os.environ["NOTEBOOKS_SESSION_PVS_ENABLED"] = "false"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -337,7 +338,17 @@ def create_pod(username, server_name, payload):
                         }
                     },
                 }
-            ]
+            ],
+            "volumes": [
+                {
+                    "name": server_name + "-git-repo",
+                    "empty_dir": {
+                        "size_limit": payload.get("serverOptions", {}).get(
+                            "disk_request"
+                        )
+                    },
+                }
+            ],
         },
     }
 

--- a/tests/test_autosaves.py
+++ b/tests/test_autosaves.py
@@ -22,7 +22,7 @@ from kubernetes.client import V1PersistentVolumeClaim, V1ObjectMeta
 from unittest.mock import patch
 
 from renku_notebooks.api import config
-from renku_notebooks.util.kubernetes_ import make_server_name
+from renku_notebooks.util.kubernetes_ import make_pvc_name
 from tests.conftest import _AttributeDictionary, CustomList
 
 AUTHORIZED_HEADERS = {"Authorization": "token 8f7e09b3bf6b8a20"}
@@ -43,8 +43,9 @@ def setup_pvcs(mocker):
         mocker.patch("renku_notebooks.api.classes.user.User._get_pvcs").return_value = [
             V1PersistentVolumeClaim(
                 metadata=V1ObjectMeta(
-                    name=make_server_name("dummyuser", project, branches[i], commits[i])
-                    + "-pvc",
+                    name=make_pvc_name(
+                        "dummyuser", "dummyuser", project, branches[i], commits[i]
+                    ),
                     annotations={
                         config.RENKU_ANNOTATION_PREFIX + "projectName": project,
                         config.RENKU_ANNOTATION_PREFIX + "namespace": "dummyuser",
@@ -127,8 +128,9 @@ def test_autosaves_only_pvs(setup_pvcs, setup_project, patch_config, client):
                 "commit": "1235435",
                 "date": tstamp.isoformat(),
                 "pvs": True,
-                "name": make_server_name("dummyuser", "project", "branch1", "1235435")
-                + "-pvc",
+                "name": make_pvc_name(
+                    "dummyuser", "dummyuser", "project", "branch1", "1235435"
+                ),
             }
         ],
         "pvsSupport": True,
@@ -160,8 +162,9 @@ def test_autosaves_branches_pvs(setup_pvcs, setup_project, patch_config, client)
                 "commit": "1235435",
                 "date": tstamp.isoformat(),
                 "pvs": True,
-                "name": make_server_name("dummyuser", "project", "branch1", "1235435")
-                + "-pvc",
+                "name": make_pvc_name(
+                    "dummyuser", "dummyuser", "project", "branch1", "1235435"
+                ),
             },
             {
                 "branch": "branch2",


### PR DESCRIPTION
This addresses a few bugs:
- Do not show ephemeral storage in the response that lists servers. The ephemeral storage is usually not related to what the user requested and can be set to a fixed value in the jupyterhub helm chart causing discrepancies between what the user asked when launching the session and what the api returns for the list of active servers.
- Use the username in the pvc. This was not the case before which would cause collisions between the pvcs for the same proejct/commit but for different users.
- Properly handle the data about disk size in the response when the api endpoint that list servers is called. This makes it so that things work with existing sessions from an old renku release where no disk size request has been set.

/deploy