### PR TITLE
fix: upper case letters in pvc name

### DIFF
--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -22,6 +22,7 @@ import os
 import warnings
 from pathlib import Path
 
+import escapism
 from kubernetes import client
 from kubernetes.config.config_exception import ConfigException
 from kubernetes.config.incluster_config import (
@@ -107,6 +108,6 @@ def make_pvc_name(safe_username, namespace, project, branch, commit_sha):
     server_string = f"{safe_username}{namespace}{project}{branch}{commit_sha}"
     return "{username}-{project}-{hash}".format(
         username=safe_username[:10].lower(),
-        project=project[:44].lower(),
+        project=escapism.escape(project, escape_char="-")[:44].lower(),
         hash=md5(server_string.encode()).hexdigest()[:8].lower(),
     )

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -106,7 +106,7 @@ def make_pvc_name(safe_username, namespace, project, branch, commit_sha):
     """Form a 16-digit hash persistent volume ID."""
     server_string = f"{safe_username}{namespace}{project}{branch}{commit_sha}"
     return "{username}-{project}-{hash}".format(
-        username=safe_username[:10],
-        project=project[:44],
-        hash=md5(server_string.encode()).hexdigest()[:8],
+        username=safe_username[:10].lower(),
+        project=project[:44].lower(),
+        hash=md5(server_string.encode()).hexdigest()[:8].lower(),
     )


### PR DESCRIPTION
I should have carefully checked what k8s requirements for PVC names are before rolling this out.

But in my tests it never occurred to me to try uppercase letters or underscores unfortunately.

Here is the regex that k8s uses to test PVC names:
```
[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
```

I.e. the only characters allowed are lowercase letters, numbers and dashes and periods.

/deploy