### PR TITLE
fix: do not fail on pvcs created with old insecure pvc naming

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -260,7 +260,11 @@ class LaunchNotebookResponse(Schema):
             else:
                 volume_name = pod.metadata.name[:54] + "-git-repo"
                 volumes = [i for i in pod.spec.volumes if i.name == volume_name]
-                if len(volumes) == 1 and volumes[0].empty_dir.size_limit is not None:
+                if (
+                    len(volumes) == 1
+                    and volumes[0].empty_dir is not None
+                    and volumes[0].empty_dir.size_limit is not None
+                ):
                     resources["storage"] = volumes[0].empty_dir.size_limit
             # remove ephemeral-storage if present
             if "ephemeral-storage" in resources.keys():


### PR DESCRIPTION
With the bugfix from [renku 0.8.5](https://github.com/SwissDataScienceCenter/renku/releases/tag/0.8.5) I changed the way the PVCs for user sessions are named. However I did not fully account for "grandfathering" the PVCs that were created after the initial functionality in renku 0.8.4 was rolled out.

This caused a bug in the following scenario:
1. a user launched a session with renku 0.8.4 with a PVC
2. the 0.8.5 release was applied which changed how renku names PVCs
3. after the 0.8.5 release listing the servers from the notebooks api fails if there are any active sessions with PVCs created in 0.8.4

This failed only when trying to list the servers - specifically where the storage amount is added to the server response data here (see comments starting with `####`:
```
#### the session is using pvc but this evaluates to false because the server class uses the pvc name 
#### to check if the pvc exists or not
if server.session_pvc is not None and server.session_pvc.pvc is not None:       
exists - so the pvc is there but not under the right name so it is as if it does not exist
    resources["storage"] = server.session_pvc.pvc.spec.resources.requests[
        "storage"
    ]
else:
#### because the if statement above evaluated to false the code goes here where it expects an emptyDir 
#### but in reality there is a pvc and when it tries to access volume.empty_dir.size we get the error we have been seeing
    volume_name = pod.metadata.name[:54] + "-git-repo"
    volumes = [i for i in pod.spec.volumes if i.name == volume_name]
    if len(volumes) == 1 and volumes[0].empty_dir.size_limit is not None:
        resources["storage"] = volumes[0].empty_dir.size_limit
```

The fix here makes it so that if there is no emptyDir and the code ends in the else portion then there is no failure and information about storage is not added to the response.

I think this is the safest way to handle this rather than to test for the old-style PVC name and add the storage data. So for the naming of PVCs with the old method the API will not report storage at all. But I think this is fine considering there aren't that many of these anyhow. And as users launch new sessions they will have properly named PVCs and be able to see the storage they are using.

/deploy