### PR TITLE
chore: prep 0.8.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for renku-notebooks
 
+## [0.8.17](https://github.com/SwissDataScienceCenter/renku-notebooks/compare/0.8.16...0.8.17) (2021-07-29)
+
+### Bug Fixes
+
+* **app:** fix failing on pvcs created with old 0.8.4 renku verison pvc naming ([fb7e318](https://github.com/SwissDataScienceCenter/renku-notebooks/commit/fb7e318dbcd7c11f1a0e723a5c1784e0a441f8d1))
+
 ## [0.8.16](https://github.com/SwissDataScienceCenter/renku-notebooks/compare/0.8.15...0.8.16) (2021-07-28)
 
 ### Bug Fixes

--- a/helm-chart/renku-notebooks/Chart.yaml
+++ b/helm-chart/renku-notebooks/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Notebooks service
 name: renku-notebooks
-version: 0.8.16
+version: 0.8.17


### PR DESCRIPTION
This addresses a bug in renku notebooks where no user sessions can be properly listed when the naming convention for user session PVC changes.

With this fix if the convention changes the user sessions can still be listed - only the disk usage for the sessions that use the old naming convention will not be shown.