### PR TITLE
fix: listing sessions when a project has been deleted

### DIFF
--- a/helm-chart/renku-notebooks/requirements.lock
+++ b/helm-chart/renku-notebooks/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: jupyterhub
   repository: https://jupyterhub.github.io/helm-chart
-  version: 0.9.1
-digest: sha256:c56de12efefcf013bc993495a3673313200143de99576843bf7da6e19372638e
-generated: "2020-10-02T14:49:46.296473+02:00"
+  version: 0.10.6
+digest: sha256:bb3fe4b56baa6130d7821b1e0461355c705963c6a1266390563797e4f5d5da2b
+generated: "2021-08-03T16:10:41.103821+02:00"

--- a/renku_notebooks/api/classes/storage.py
+++ b/renku_notebooks/api/classes/storage.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from flask import current_app
+from gitlab.exceptions import GitlabGetError
 from kubernetes import client
 from kubernetes.client.models.v1_resource_requirements import V1ResourceRequirements
 import requests
@@ -18,19 +19,11 @@ class Autosave:
         self.project = self.namespace_project.split("/")[-1]
         self.gl_project = self.user.get_renku_project(self.namespace_project)
         self.root_branch_name = root_branch_name
-        if len(root_commit_sha) < 40:
-            root_commit_sha = self.gl_project.commits.get(root_commit_sha).id
         self.root_commit_sha = root_commit_sha
-        if self.gl_project is None:
-            raise ValueError(f"Project {self.namespace_project} does not exist.")
-        self.gl_root_branch = self.gl_project.branches.get(self.root_branch_name)
-        if self.gl_root_branch is None:
-            raise ValueError(
-                f"Branch {self.root_branch_name} for project "
-                f"{self.namespace_project} does not exist."
-            )
+        self.validated = False
 
     def _root_commit_is_parent_of(self, commit_sha):
+        self.validate()
         res = requests.get(
             headers={"Authorization": f"Bearer {self.user.oauth_token}"},
             url=f"{current_app.config['GITLAB_URL']}/api/v4/"
@@ -41,6 +34,32 @@ class Autosave:
             return True
         else:
             return False
+
+    def validate(self):
+        if self.validated:
+            return
+        if self.gl_project is None:
+            raise ValueError(f"Project {self.namespace_project} does not exist.")
+        try:
+            root_commit_sha = self.gl_project.commits.get(self.root_commit_sha).id
+            if len(self.root_commit_sha) < 40:
+                self.root_commit_sha = root_commit_sha
+        except GitlabGetError:
+            raise ValueError("Root commit sha {root_commit_sha} does not exist.")
+        if hasattr(self, "final_commit_sha"):
+            try:
+                final_commit_sha = self.gl_project.commits.get(self.final_commit_sha).id
+                if len(self.final_commit_sha) < 40:
+                    self.final_commit_sha = final_commit_sha
+            except GitlabGetError:
+                raise ValueError("Final commit sha {root_commit_sha} does not exist.")
+        self.gl_root_branch = self.gl_project.branches.get(self.root_branch_name)
+        if self.gl_root_branch is None:
+            raise ValueError(
+                f"Branch {self.root_branch_name} for project "
+                f"{self.namespace_project} does not exist."
+            )
+        self.validated = True
 
     def cleanup(self, session_commit_sha):
         if self._root_commit_is_parent_of(session_commit_sha):
@@ -74,8 +93,6 @@ class AutosaveBranch(Autosave):
         final_commit_sha,
     ):
         super().__init__(user, namespace_project, root_branch_name, root_commit_sha)
-        if len(final_commit_sha) < 40:
-            final_commit_sha = self.gl_project.commits.get(final_commit_sha).id
         self.final_commit_sha = final_commit_sha
         self.name = (
             f"renku/autosave/{self.user.hub_username}/{root_branch_name}/"
@@ -105,9 +122,10 @@ class AutosaveBranch(Autosave):
     def from_branch_name(cls, user, namespace_project, autosave_branch_name):
         match_res = re.match(cls.branch_name_regex, autosave_branch_name)
         if match_res is None:
-            raise ValueError(
+            current_app.logger.warning(
                 f"Invalid branch name {autosave_branch_name} for autosave branch."
             )
+            return None
         return cls(
             user,
             namespace_project,
@@ -145,6 +163,7 @@ class SessionPVC(Autosave):
             )
 
     def create(self, storage_size, storage_class):
+        self.validate()
         # check if we already have this PVC
         pvc = self.pvc
         if pvc is not None:
@@ -245,7 +264,8 @@ class SessionPVC(Autosave):
             root_commit_sha is None,
         ]
         if any(parameters_missing):
-            raise ValueError(
+            current_app.logger.warning(
                 "Required PVC annotations for creating SessionPVC are missing."
             )
+            return None
         return cls(user, f"{namespace}/{project}", root_branch_name, root_commit_sha)

--- a/renku_notebooks/api/classes/storage.py
+++ b/renku_notebooks/api/classes/storage.py
@@ -21,45 +21,62 @@ class Autosave:
         self.root_branch_name = root_branch_name
         self.root_commit_sha = root_commit_sha
         self.validated = False
+        self.valid = False
+        self.validation_messages = []
 
     def _root_commit_is_parent_of(self, commit_sha):
         self.validate()
-        res = requests.get(
-            headers={"Authorization": f"Bearer {self.user.oauth_token}"},
-            url=f"{current_app.config['GITLAB_URL']}/api/v4/"
-            f"projects/{self.gl_project.id}/repository/merge_base",
-            params={"refs[]": [self.root_commit_sha, commit_sha]},
-        )
-        if res.status_code == 200 and res.json().get("id") == self.root_commit_sha:
-            return True
-        else:
-            return False
+        if self.valid:
+            res = requests.get(
+                headers={"Authorization": f"Bearer {self.user.oauth_token}"},
+                url=f"{current_app.config['GITLAB_URL']}/api/v4/"
+                f"projects/{self.gl_project.id}/repository/merge_base",
+                params={"refs[]": [self.root_commit_sha, commit_sha]},
+            )
+            if res.status_code == 200 and res.json().get("id") == self.root_commit_sha:
+                return True
+        return False
 
-    def validate(self):
-        if self.validated:
+    def validate(self, force_rerun=False):
+        if self.validated and not force_rerun:
             return
+        validation_messages = []
         if self.gl_project is None:
-            raise ValueError(f"Project {self.namespace_project} does not exist.")
+            validation_messages.append(
+                f"Project {self.namespace_project} does not exist."
+            )
         try:
             root_commit_sha = self.gl_project.commits.get(self.root_commit_sha).id
             if len(self.root_commit_sha) < 40:
                 self.root_commit_sha = root_commit_sha
         except GitlabGetError:
-            raise ValueError("Root commit sha {root_commit_sha} does not exist.")
+            validation_messages.append(
+                "Root commit sha {root_commit_sha} does not exist."
+            )
         if hasattr(self, "final_commit_sha"):
             try:
                 final_commit_sha = self.gl_project.commits.get(self.final_commit_sha).id
                 if len(self.final_commit_sha) < 40:
                     self.final_commit_sha = final_commit_sha
             except GitlabGetError:
-                raise ValueError("Final commit sha {root_commit_sha} does not exist.")
+                validation_messages.append(
+                    "Final commit sha {root_commit_sha} does not exist."
+                )
         self.gl_root_branch = self.gl_project.branches.get(self.root_branch_name)
         if self.gl_root_branch is None:
-            raise ValueError(
+            validation_messages.append(
                 f"Branch {self.root_branch_name} for project "
                 f"{self.namespace_project} does not exist."
             )
         self.validated = True
+        if len(validation_messages) == 0:
+            self.valid = True
+        else:
+            current_app.logger.warning(
+                "Validation for autosave branch/pvc "
+                f"failed because: {validation_messages.join(', ')}"
+            )
+        self.validation_messages = validation_messages
 
     def cleanup(self, session_commit_sha):
         if self._root_commit_is_parent_of(session_commit_sha):
@@ -164,6 +181,10 @@ class SessionPVC(Autosave):
 
     def create(self, storage_size, storage_class):
         self.validate()
+        if not self.valid:
+            raise ValueError(
+                "Cannot create PVC because of invalid or missing parameters."
+            )
         # check if we already have this PVC
         pvc = self.pvc
         if pvc is not None:

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -100,11 +100,16 @@ class User:
         for project in projects:
             for branch in project.branches.list():
                 if re.match(r"^renku\/autosave\/", branch.name) is not None:
-                    autosaves.append(
-                        AutosaveBranch.from_branch_name(
-                            self, namespace_project, branch.name
-                        )
+                    autosave = AutosaveBranch.from_branch_name(
+                        self, namespace_project, branch.name
                     )
+                    if autosave is not None:
+                        autosaves.append(autosave)
+                    else:
+                        current_app.logger.warning(
+                            "Autosave branch {branch} for "
+                            f"{namespace_project} cannot be instantiated."
+                        )
         return autosaves
 
     def _get_pvcs(self):


### PR DESCRIPTION
This addresses a bug where the noteboook service is unable to generate the list of active user sessions when a session exists whose project has been deleted or changed in some ways.

The bug occurs when:
- a user creates a session then deletes the project but leaves the session
- a user creates a session then deletes the branch tied to the session but leaves the session
- a user creates a session then transfers the project to a different group/namespace but leaves the session

The bug is caused by the code in the Autosave class validating the existence of several gitlab resources (i.e. branch, commit, project, etc) even if this is not always required. And in addition to doing this validation the code would raise exceptions when these validation failed. So when a user gets into one of the scenarios described above then the validation in the Autosave classes raises an exception that prevents further listing or processing of other sessions. With these changes the session that has been "orphaned" like this will not interfere with listing other valid sessions and it will appear when a user tries to list all sessions regardless of the project.

/deploy