### PR TITLE
fix: git proxy should let through unrecognized requests

### DIFF
--- a/git-https-proxy/mitmproxy.js
+++ b/git-https-proxy/mitmproxy.js
@@ -85,23 +85,13 @@ proxy.onRequest(function (ctx, callback) {
     return callback();
   }
 
-  if (
-    // User is not anonymous and request is for the git repository.
-    // Important: make sure that we're not adding the users token to a commit
-    // to another git host, repo, etc.
-    !anonymousSession && validGitRequest
-  ) {
-    console.log(`Adding auth header to request: ${requestUrl}`);
-    ctx.proxyToServerRequestOptions.headers['Authorization'] =
-      `Basic ${encodedCredentials}`;
-    return callback();
-  }
-
-  console.log(`Prevented access to: ${requestUrl}`);
-  ctx.proxyToClientResponse.end(
-    `This proxy does not allow you to access ${requestUrl}\n`
-  );
-  // No callback here returned here, so this request will not be forwarded!
+  // User is not anonymous and request is for the git repository.
+  // Important: make sure that we're not adding the users token to a commit
+  // to another git host, repo, etc.
+  console.log(`Adding auth header to request: ${requestUrl}`);
+  ctx.proxyToServerRequestOptions.headers['Authorization'] =
+    `Basic ${encodedCredentials}`;
+  return callback();
 
 });
 


### PR DESCRIPTION
So after testing using git LFS on https://ci-renku-2142.dev.renku.ch/ I realized that things dont work.

And the reason is that the git proxy will block requests if the user is logged in and there are requests that are not directed to the git repo (i.e the git repos url). 

This essentially blocks some requests that git/git-lfs sends directly to the object storage that backs git LFS:
```
Prevented access to: https://os.zhdk.cloud.switch.ch/dev-lfs-objects/17/49/2d449dadb0d5cb10399b25c04fae8d44f62e1c511b90106689c4207e14ad?AWSAccessKeyId=XXXXXXXX&Signature=XXXXXXXXExpires=1630928506
```

This change should let through requests (without adding the auth headers for git) if the request is not for the git repository but the user is still logged in.