### PR TITLE
fix: add credentials in git proxy if host matches

### DIFF
--- a/git-https-proxy/mitmproxy.js
+++ b/git-https-proxy/mitmproxy.js
@@ -72,8 +72,7 @@ proxy.onRequest(function (ctx, callback) {
 
   const validGitRequest = ctx.proxyToServerRequestOptions.agent.protocol === repoUrl.protocol &&
     ctx.proxyToServerRequestOptions.port === (repoUrl.port || defaultPort) &&
-    ctx.proxyToServerRequestOptions.host === repoUrl.host &&
-    ctx.proxyToServerRequestOptions.path.startsWith(repoUrl.pathname)
+    ctx.proxyToServerRequestOptions.host === repoUrl.host
 
   if (anonymousSession) {
     console.log(`Anonymous session, not adding auth headers, letting request through without adding auth headers.`);


### PR DESCRIPTION
@ableuler I think we need to further relax the conditions under which we add the credentials in the git proxy.

As things currently stand (either in this branch or what we have in production) users cannot add another remote in the repository from the same git server. This is because another remote will have a different path (but the same host, port and protocol). 

This is probably not affecting a lot of users but if you want to pull changes from an upstream repository from which you have forked you have to do this. And when you try to do this (at least with an internal project) you have to provide a password and username for git. Even though the repository is on the same server.

Let me know what you think.

Here is an example internal project that I was testing with: https://renkulab.io/projects/tasko.olevski/maristem-omics