### PR TITLE
fix: assignment of culling idle threshold for anonymous sessions

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -778,7 +778,7 @@ class UserServer:
                         current_app.config[
                             "CULLING_REGISTERED_IDLE_SESSIONS_THRESHOLD_SECONDS"
                         ]
-                        if type(self._user is RegisteredUser)
+                        if type(self._user) is RegisteredUser
                         else current_app.config[
                             "CULLING_ANONYMOUS_IDLE_SESSIONS_THRESHOLD_SECONDS"
                         ]


### PR DESCRIPTION
Reopened #750 to avoid the large number of commits in the PRs.