### PR TITLE
fix: user jupyter notebook as arg for launching a server

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -15,7 +15,8 @@ ENV PATH=$PATH:/.renku/bin
 RUN mkdir -p /.renku/bin && \
     virtualenv /.renku/venv && \
     . /.renku/venv/bin/activate && \
-    pip install --no-cache renku && \
+    pip install --no-cache-dir setuptools==57.5.0 && \
+    pip install --no-cache renku==0.16.1 && \
     deactivate && \
     ln -s /.renku/venv/bin/renku /.renku/bin/renku
 

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -686,7 +686,7 @@ class UserServer:
                     {
                         "op": "add",
                         "path": "/statefulset/spec/template/spec/containers/0/args",
-                        "value": ["jupyter", "lab"],
+                        "value": ["jupyter", "notebook"],
                     }
                 ],
             }


### PR DESCRIPTION
When the `jupyter lab` command is used to start a session then the default URL for it cannot be changed and it is always `/lab` this is a problem for images that user rstudio.

/deploy renku=notebooks-operator-poc