### PR TITLE
fix(app): when a gitlab project does not exist log a warning not error

### DIFF
--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -41,7 +41,7 @@ class User(ABC):
         try:
             return self.gitlab_client.projects.get("{0}".format(namespace_project))
         except Exception as e:
-            current_app.logger.error(
+            current_app.logger.warning(
                 f"Cannot get project: {namespace_project} for user: {self.username}, error: {e}"
             )
 


### PR DESCRIPTION
There can be many occasions when a gitlab project is found to not exist when the code expects it to exist.

In all such cases flasks logger is used to post an error. However this is then also picked up by sentry and it causes unnecessary notifications.

I was able to reproduce this error by:
- creating a project
- launching a sessions
- deleting the project in gitlab while remaining on the sessions page in the ui
- any request to list the sessions after this causes the error to show up in the logs and in sentry

I can confirm that even though the gitlab project is deleted but the session still exists the notebooks service properly lists the session and does not crash or return code 500. But there is an error message in the logs every time a request to the API is sent.