### PR TITLE
fix(app): use the right storage class name parameter in Jupyter server

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -732,7 +732,7 @@ class UserServer:
                 "size": self.server_options["disk_request"],
                 "pvc": {
                     "enabled": True,
-                    "storageClass": current_app.config[
+                    "storageClassName": current_app.config[
                         "NOTEBOOKS_SESSION_PVS_STORAGE_CLASS"
                     ],
                     "mountPath": self.image_workdir.rstrip("/") + "/work",


### PR DESCRIPTION
Amalthea does not complain when unknown fields are provided for the Jupyter server manifest. So in this case the storage class name was mismatched and it was ignored - i.e. as if it was not provided. And if the storage class is not provided then the default storage class is used. Which in many cases has a "retain" policy.