### PR TITLE
feat(app): use Amalthea version 0.1.0

### DIFF
--- a/helm-chart/renku-notebooks/requirements.lock
+++ b/helm-chart/renku-notebooks/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: amalthea
   repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.1.0-rc11
-digest: sha256:25be996e8e9d552b70fcd723f685248240396e72c75479dc2fe0292bb80ca0ce
-generated: "2021-09-15T15:09:02.388121+02:00"
+  version: 0.1.0
+digest: sha256:6e8dc920d41f26aed6c45d94f711f2a21911634d8148fd49eb5be28cf284cd0f
+generated: "2021-10-05T11:41:31.39154+02:00"

--- a/helm-chart/renku-notebooks/requirements.yaml
+++ b/helm-chart/renku-notebooks/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: amalthea
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: 0.1.0-rc11
+  version: 0.1.0

--- a/tests/integration/test_server_options.py
+++ b/tests/integration/test_server_options.py
@@ -138,7 +138,7 @@ def valid_server_options(request, min_server_options, valid_extra_range_options)
     elif request.param == "out_of_range":
         return valid_extra_range_options
     elif request.param in SERVER_OPTIONS_NO_VALIDATION:
-        return {"defaultUrl": "random_url"}
+        return {"defaultUrl": "/lab"}
     else:
         return {request.param: min_server_options[request.param]}
 


### PR DESCRIPTION
Use the latest version of Amalthea. Prior to this `0.1.0-rc11`. This is almost identical to `0.1.0` without any major functionality missing. However it is better to switch to a proper release and not a release candidate.