### PR TITLE
fix(app): make size limit optional for empty dir user session storage

### DIFF
--- a/helm-chart/renku-notebooks/templates/deployment.yaml
+++ b/helm-chart/renku-notebooks/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             - name: NOTEBOOKS_SESSION_PVS_STORAGE_CLASS
               value: {{ .Values.userSessionPersistentVolumes.storageClass | quote}}
             {{ end }}
+            - name: USE_EMPTY_DIR_SIZE_LIMIT
+              value: {{ .Values.userSessionPersistentVolumes.useEmptyDirSizeLimit | quote }}
             - name: NOTEBOOKS_DEFAULT_IMAGE
               value: "{{ .Values.jupyterhub.singleuser.image.name }}:{{ .Values.jupyterhub.singleuser.image.tag }}"
             - name: NOTEBOOKS_SERVER_OPTIONS_DEFAULTS_PATH

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -13,6 +13,7 @@ global:
 userSessionPersistentVolumes:
   enabled: false
   storageClass:
+  useEmptyDirSizeLimit: true
 
 gitlab:
   ## specify the GitLab instance URL

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -383,7 +383,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
             epehemeral_storage_req = getattr(
                 getattr(notebook_container, "resources", {}), "requests", {}
             ).get("ephemeral-storage")
-            if epehemeral_storage_req is not None:
+            if epehemeral_storage_req is not None and "disk_request" in server_options.keys():
                 notebook_container.resources.requests["ephemeral-storage"] = (
                     str(
                         round(
@@ -396,7 +396,7 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
                     )
                     + "Gi"
                 )
-            if epehemeral_storage_lim is not None:
+            if epehemeral_storage_lim is not None and "disk_request" in server_options.keys():
                 notebook_container.resources.limits["ephemeral-storage"] = (
                     str(
                         round(

--- a/jupyterhub/spawners.py
+++ b/jupyterhub/spawners.py
@@ -217,7 +217,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         if not options.get("pvc_name"):
             volume = {
                 "name": git_volume_name,
-                "emptyDir": {"sizeLimit": server_options["disk_request"]},
+                "emptyDir": {"sizeLimit": server_options["disk_request"]}
+                if server_options.get("disk_request") is not None
+                else {},
             }
         else:
             volume = {
@@ -371,7 +373,9 @@ class RenkuKubeSpawner(SpawnerMixin, KubeSpawner):
         # to account for the ephemeral storage taken up by the session
         if not options.get("pvc_name"):
             notebook_container = [
-                container for container in pod.spec.containers if container.name == "notebook"
+                container
+                for container in pod.spec.containers
+                if container.name == "notebook"
             ][0]
             epehemeral_storage_lim = getattr(
                 getattr(notebook_container, "resources", {}), "limits", {}

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -46,6 +46,13 @@ class UserServer:
         self.commit_sha = commit_sha
         self.notebook = notebook
         self.image = image
+        if (
+            not current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"]
+            and not current_app.config["USE_EMPTY_DIR_SIZE_LIMIT"]
+        ):
+            # remove the disk request field to indicate to the spawner that
+            # a limit on the size of the empty dir should not be imposed
+            server_options.pop("disk_request")
         self.server_options = server_options
         self.using_default_image = self.image == current_app.config.get("DEFAULT_IMAGE")
         self.session_pvc = (

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -46,7 +46,7 @@ class UserServer:
         self.commit_sha = commit_sha
         self.notebook = notebook
         self.image = image
-        
+
         self.server_options = server_options
         self.using_default_image = self.image == current_app.config.get("DEFAULT_IMAGE")
         self.session_pvc = (

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -46,13 +46,7 @@ class UserServer:
         self.commit_sha = commit_sha
         self.notebook = notebook
         self.image = image
-        if (
-            not current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"]
-            and not current_app.config["USE_EMPTY_DIR_SIZE_LIMIT"]
-        ):
-            # remove the disk request field to indicate to the spawner that
-            # a limit on the size of the empty dir should not be imposed
-            server_options.pop("disk_request")
+        
         self.server_options = server_options
         self.using_default_image = self.image == current_app.config.get("DEFAULT_IMAGE")
         self.session_pvc = (
@@ -235,6 +229,14 @@ class UserServer:
         gl_project = self._user.gitlab_client.projects.get(
             f"{self.namespace}/{self.project}"
         )
+        server_options = {**self.server_options}
+        if (
+            not current_app.config["NOTEBOOKS_SESSION_PVS_ENABLED"]
+            and not current_app.config["USE_EMPTY_DIR_SIZE_LIMIT"]
+        ):
+            # remove the disk request field to indicate to the spawner that
+            # a limit on the size of the empty dir should not be imposed
+            server_options.pop("disk_request", None)
         payload = {
             "namespace": self.namespace,
             "project": self.project,
@@ -245,7 +247,7 @@ class UserServer:
             "image": verified_image,
             "git_clone_image": current_app.config["GIT_CLONE_IMAGE"],
             "git_https_proxy_image": current_app.config["GIT_HTTPS_PROXY_IMAGE"],
-            "server_options": self.server_options,
+            "server_options": server_options,
         }
 
         if current_app.config["GITLAB_AUTH"] and is_image_private:

--- a/renku_notebooks/config.py
+++ b/renku_notebooks/config.py
@@ -92,6 +92,10 @@ NOTEBOOKS_SESSION_PVS_STORAGE_CLASS = os.environ.get(
 )
 """Use a custom storage class for the user session persistent volumes."""
 
+USE_EMPTY_DIR_SIZE_LIMIT = (
+    os.environ.get("USE_EMPTY_DIR_SIZE_LIMIT", "true").lower() == "true"
+)
+
 OPENAPI_VERSION = "2.0"
 API_SPEC_URL = f"{SERVICE_PREFIX}/api/v1/spec"
 SWAGGER_URL = f"{SERVICE_PREFIX}/api/docs"


### PR DESCRIPTION
By using the following field in the values.yaml file
```
userSessionPersistentVolumes:
  useEmptyDirSizeLimit: true
```

One can enable or disable imposing a limit on the empty dir (if empty dirs are used for user sessions).