### PR TITLE
fix(app): master is always checked out

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -395,7 +395,7 @@ class UserServer:
                                     else "0",
                                 },
                                 {"name": "COMMIT_SHA", "value": self.commit_sha},
-                                {"name": "BRANCH", "value": "master"},
+                                {"name": "BRANCH", "value": self.branch},
                                 {
                                     # used only for naming autosave branch
                                     "name": "RENKU_USERNAME",


### PR DESCRIPTION
This slipped through the cracks and caused the issue reported in #801.

Closes #801 

/deploy