### PR TITLE
fix(chart): use current fallback renku image

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -142,7 +142,7 @@ serverDefaults:
   lfs_auto_fetch: false
 
 ## Default image used when the requested image for a user session cannot be found.
-defaultSessionImage: "renku/singleuser:latest"
+defaultSessionImage: "renku/renkulab-py:3.9-0.10.1"
 
 gitRpcServer:
   image:


### PR DESCRIPTION
So yeah this slipped through the cracks a bit. I would have preferred to use a `latest` tab, but renkulab-py does not have `latest` tags.