### PR TITLE
chore(app): Update default session image to renku/renkulab-py:3.9-tast-auto-update-10

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -160,7 +160,7 @@ serverDefaults:
 enforceCPULimits: "off"
 
 ## Default image used when the requested image for a user session cannot be found.
-defaultSessionImage: "renku/renkulab-py:3.9-0.10.1"
+defaultSessionImage: renku/renkulab-py:3.9-tast-auto-update-10
 
 gitRpcServer:
   image:


### PR DESCRIPTION
Generated automatically on a new release in renkulab-docker to update the default image used when launching a user session.