### PR TITLE
fix(app): disable renku cli version check

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -647,6 +647,11 @@ class UserServer:
                         "path": "/statefulset/spec/template/spec/containers/0/env/-",
                         "value": {"name": "GIT_CLONE_REPO", "value": "true"},
                     },
+                    {
+                        "op": "add",
+                        "path": "/statefulset/spec/template/spec/containers/0/env/-",
+                        "value": {"name": "RENKU_DISABLE_VERSION_CHECK", "value": "1"},
+                    },
                 ],
             }
         )


### PR DESCRIPTION
Prevents the renku cli from checking for the latest version and printing a message about the upgrading every time a user runs a renku cli command.