### PR TITLE
fix(app): do not accept an empty anonymous user id

### DIFF
--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -55,7 +55,12 @@ class AnonymousUser(User):
             raise ValueError(
                 "Cannot use AnonymousUser when anonymous sessions are not enabled."
             )
-        self.authenticated = self.auth_header in headers.keys()
+        self.authenticated = (
+            self.auth_header in headers.keys()
+            and headers[self.auth_header] != ""
+            # The anonymous id must start with an alphanumeric character
+            and re.match(r"^[a-zA-Z0-9]", headers[self.auth_header]) is not None
+        )
         if not self.authenticated:
             return
         self.gitlab_client = Gitlab(current_app.config["GITLAB_URL"], api_version=4)


### PR DESCRIPTION
The gateway defaults to anonymous user id set to `""` when one is not found in the cookie for a users session. But having a token set to `""` results in improper k8s resource names. I.e. the sessions are named like `f"{user-id}-some-other-snippet"`. And when the anonymous user id is blank the resources in k8s are named starting with `-` and k8s does not allow this.

Also because of k8s naming restrictions and how the id is used in naming resources the anonymous id must start with an alphanumeric character. I added a check for this too.

/deploy (just to be sure)