### PR TITLE
chore: track release version in sentry

### DIFF
--- a/helm-chart/renku-notebooks/templates/statefulset.yaml
+++ b/helm-chart/renku-notebooks/templates/statefulset.yaml
@@ -108,6 +108,8 @@ spec:
             - name: SENTRY_SAMPLE_RATE
               value: {{ .Values.sentry.sampleRate | quote }}
             {{ end }}
+            - name: SENTRY_RELEASE
+              value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             - name: CERTIFICATES_IMAGE
               value: "{{ .Values.global.certificates.image.repository }}:{{ .Values.global.certificates.image.tag }}"
             - name: CUSTOM_CA_CERTS_SECRETS

--- a/helm-chart/renku-notebooks/templates/statefulset.yaml
+++ b/helm-chart/renku-notebooks/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
               value: {{ .Values.sentry.sampleRate | quote }}
             {{ end }}
             - name: SENTRY_RELEASE
-              value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              value: {{ .Chart.Version | quote }}
             - name: CERTIFICATES_IMAGE
               value: "{{ .Values.global.certificates.image.repository }}:{{ .Values.global.certificates.image.tag }}"
             - name: CUSTOM_CA_CERTS_SECRETS


### PR DESCRIPTION
According to the docs here: https://docs.sentry.io/platforms/python/configuration/releases/

Setting an environment variable like `SENTRY_RELEASE` will be picked up automatically by sentry and used to distinguish and track different release versions.