### PR TITLE
fix(app): remove S3 flag from server options

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -286,9 +286,11 @@ def server_options(user):
     return ServerOptionsUI().dump(
         {
             **current_app.config["SERVER_OPTIONS_UI"],
-            "cloudstorage": {
-                "s3": {"enabled": current_app.config["S3_MOUNTS_ENABLED"]}
-            },
+            # TODO: enable when the UI supports fully s3 buckets
+            # currently passing this breaks the sessions settings page
+            # "cloudstorage": {
+            #     "s3": {"enabled": current_app.config["S3_MOUNTS_ENABLED"]}
+            # },
         },
     )
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -537,7 +537,9 @@ class ServerOptionsUI(Schema):
     disk_request = fields.Nested(
         ServerOptionUIDisk(), required="disk_request" in config.SERVER_OPTIONS_UI.keys()
     )
-    cloudstorage = fields.Nested(CloudStorageServerOption(), required=True)
+    # TODO: enable when the UI supports fully s3 buckets
+    # currently passing this breaks the sessions settings page
+    # cloudstorage = fields.Nested(CloudStorageServerOption(), required=True)
 
 
 class ServerLogs(Schema):

--- a/tests/integration/test_session_creation.py
+++ b/tests/integration/test_session_creation.py
@@ -147,9 +147,11 @@ def test_can_get_server_options(base_url, headers, server_options_ui):
     assert response.status_code == 200
     assert response.json() == {
         **server_options_ui,
-        "cloudstorage": {
-            "s3": {"enabled": os.getenv("S3_MOUNTS_ENABLED", "false") == "true"}
-        },
+        # NOTE: enable when the UI fully supports s3
+        # currently this breaks the session settings page
+        # "cloudstorage": {
+        #     "s3": {"enabled": os.getenv("S3_MOUNTS_ENABLED", "false") == "true"}
+        # },
     }
 
 


### PR DESCRIPTION
Turns out this breaks the ui - specifically the session settings page. We only expected the page that lets you start a session to be affected and that was fine. But the session settings page broke and we did not notice.