### PR TITLE
fix(app): enable s3 flag in server options

### DIFF
--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -319,11 +319,9 @@ def server_options(user):
     return ServerOptionsUI().dump(
         {
             **current_app.config["SERVER_OPTIONS_UI"],
-            # TODO: enable when the UI supports fully s3 buckets
-            # currently passing this breaks the sessions settings page
-            # "cloudstorage": {
-            #     "s3": {"enabled": current_app.config["S3_MOUNTS_ENABLED"]}
-            # },
+            "cloudstorage": {
+                "s3": {"enabled": current_app.config["S3_MOUNTS_ENABLED"]}
+            },
         },
     )
 

--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -642,9 +642,7 @@ class ServerOptionsUI(Schema):
     disk_request = fields.Nested(
         ServerOptionUIDisk(), required="disk_request" in config.SERVER_OPTIONS_UI.keys()
     )
-    # TODO: enable when the UI supports fully s3 buckets
-    # currently passing this breaks the sessions settings page
-    # cloudstorage = fields.Nested(CloudStorageServerOption(), required=True)
+    cloudstorage = fields.Nested(CloudStorageServerOption(), required=True)
 
 
 _ServerLogs = Schema.from_dict({"jupyter-server": fields.String(required=False)})

--- a/tests/integration/test_session_creation.py
+++ b/tests/integration/test_session_creation.py
@@ -165,11 +165,9 @@ def test_can_get_server_options(base_url, headers, server_options_ui):
     assert response.status_code == 200
     assert response.json() == {
         **server_options_ui,
-        # NOTE: enable when the UI fully supports s3
-        # currently this breaks the session settings page
-        # "cloudstorage": {
-        #     "s3": {"enabled": os.getenv("S3_MOUNTS_ENABLED", "false") == "true"}
-        # },
+        "cloudstorage": {
+            "s3": {"enabled": os.getenv("S3_MOUNTS_ENABLED", "false") == "true"}
+        },
     }
 
 


### PR DESCRIPTION
/deploy #persist

So this was breaking the ui and it was commented out when merged.

Now that the ui fully supports s3 buckets it should be enabled fully. I forgot to do this earlier when I did the 1.5.0 release of notebooks. It would have been ideal to do it then.