### PR TITLE
chore(ci): make master the target for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,4 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "dependabot-updates"
+    target-branch: "master"


### PR DESCRIPTION
Currently dependabot merges the updates in its own dedicated branch. But when new packages are installed or when things change substatially then this dedicated branch gets out of sync. Bringing this up to date usually results in conflicts and requires rerunning pipenv to re-lock things and it is a pain.

The integration tests that run with every commit now and the acceptance tests that we usually run on every release and even more often are enough to catch any issues. And there is not need to keep merging things into a dedicated branch and release the updates in batches.