### PR TITLE
fix(app): handle user names in git clone

### DIFF
--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -63,9 +63,9 @@ class GitCloner:
         self.cli.git_init()
         # NOTE: For anonymous sessions email and name are not known for the user
         if self.user.email is not None:
-            self.cli.git_config(f"user.email {self.user.email}")
+            self.cli.git_config(f"user.email '{self.user.email}'")
         if self.user.full_name is not None:
-            self.cli.git_config(f"user.name {self.user.full_name}")
+            self.cli.git_config(f"user.name '{self.user.full_name}'")
         self.cli.git_config("push.default simple")
 
     def _setup_proxy(self):


### PR DESCRIPTION
Fixes a problem with names with a middle name during the setup of the repo when launching a session.

This was introduced by the conversion of the "git clone" code from bash to python.