### PR TITLE
fix(chart): revert the removal of autosave bash script

### DIFF
--- a/helm-chart/renku-notebooks/templates/configmap.yaml
+++ b/helm-chart/renku-notebooks/templates/configmap.yaml
@@ -13,3 +13,47 @@ data:
     {{ .Values.serverOptions | default dict | toJson }}
   server_defaults.json: |
     {{ toJson .Values.serverDefaults }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notebook-helper-scripts
+  labels:
+    app: {{ template "notebooks.name" . }}
+    chart: {{ template "notebooks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pre-stop.sh: |
+    #!/bin/bash
+    UNCOMMITTED_CHANGES=`git status -s`
+    UNPUSHED_COMMITS=`git log --branches --not --remotes`
+    if [ "${GIT_AUTOSAVE}" != "1" ] ; then
+      exit 0
+    fi
+    if [ -z "$UNCOMMITTED_CHANGES" ] && [ -z "$UNPUSHED_COMMITS" ]; then
+      exit 0
+    fi
+    CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+    LOCAL_SHA=`git rev-parse --short HEAD`
+    INITIAL_SHA="${CI_COMMIT_SHA:0:7}"
+    AUTOSAVE_BRANCH="renku/autosave/$RENKU_USERNAME/${CURRENT_BRANCH}/${INITIAL_SHA}/${LOCAL_SHA}"
+    if [ -z "$UNCOMMITTED_CHANGES" ] && [ ! -z "$UNPUSHED_COMMITS" ]; then
+      # there are only unpushed commits
+      git checkout -b "$AUTOSAVE_BRANCH"
+      git push origin "$AUTOSAVE_BRANCH"
+      git checkout "$CURRENT_BRANCH"
+      git branch -D "$AUTOSAVE_BRANCH"
+    fi
+    if [ ! -z "$UNCOMMITTED_CHANGES" ]; then
+      # there are uncommitted changes
+      git stash --include-untracked
+      git checkout -b "$AUTOSAVE_BRANCH"
+      git stash apply
+      git add .
+      git commit -am "Auto-saving for $RENKU_USERNAME on branch $CURRENT_BRANCH from commit $INITIAL_SHA"
+      git push origin "$AUTOSAVE_BRANCH"
+      git checkout "$CURRENT_BRANCH"
+      git branch -D "$AUTOSAVE_BRANCH"
+      git stash pop
+    fi


### PR DESCRIPTION
In [this PR](https://github.com/SwissDataScienceCenter/renku-notebooks/pull/956/files#diff-0511dfda400363ade263615b5f47306c36858ceff72528e67296e5b1d741168f) I replaced the autosave script with python and removed the section of the configmap that contains the old bash autosave script.

However this means that sessions launched before the new renku version was released cannot create autosave branches.

I will open an issue to retire this bash script in a later release.