### PR TITLE
chore(ci): fix action that lints helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -62,13 +61,8 @@ jobs:
         uses: azure/setup-helm@v1
       - name: Test chart
         run: |
-          PATH=${{ runner.temp }}/linux-amd64/:$PATH
+          helm dep update helm-chart/renku-notebooks
           helm lint helm-chart/renku-notebooks
-      - name: Build chart and images
-        run: |
-          python -m pip install --upgrade pip pipenv
-          pipenv install --deploy --system --dev
-          chartpress
 
   publish-chart-tagged:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In a previous PR I cleaned up the action that lints the helm chart. 

But there is still a few things that I forgot and left over. Also the chart linting was set to happen only on merge to master or release.

Now the chart will be linted on every push. In addition since all unit tests run on every commit there is no need to build the images (and not publish them) at the last step of the job that lints the helm chart.

The images are still built on every commit when their respective unit tests run. And the images are also built when the chart or images are published.