### PR TITLE
fix(app): eliminate unnecessary gitlab calls

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -140,8 +140,10 @@ class UserServer:
         if self.branch is not None and self.gl_project is not None:
             try:
                 self.gl_project.branches.get(self.branch)
-            except Exception:
-                pass
+            except Exception as err:
+                current_app.logger.warning(
+                    f"Branch {self.branch} cannot be verified or does not exist. {err}"
+                )
             else:
                 return True
         return False
@@ -151,8 +153,10 @@ class UserServer:
         if self.commit_sha is not None and self.gl_project is not None:
             try:
                 self.gl_project.commits.get(self.commit_sha)
-            except Exception:
-                pass
+            except Exception as err:
+                current_app.logger.warning(
+                    f"Commit {self.commit_sha} cannot be verified or does not exist. {err}"
+                )
             else:
                 return True
         return False

--- a/tests/integration/test_session_creation.py
+++ b/tests/integration/test_session_creation.py
@@ -92,8 +92,9 @@ def test_can_delete_created_notebooks(
     )
     assert response.status_code == 204
     response = requests.get(f"{base_url}/servers/{server_name}", headers=headers)
-    assert response.status_code == 200
-    assert not response.json().get("status").get("ready")
+    assert response.status_code == 404 or (
+        response.status_code == 200 and not response.json().get("status").get("ready")
+    )
 
 
 def test_recreating_notebooks_returns_current_server(


### PR DESCRIPTION
There are unnecessary calls to the gitlab api when servers are instantiated.

In addition some properties can be cached so that they are quicker when they are called more than once.

/deploy