### PR TITLE
squashme: make error messages properly surface

### DIFF
--- a/git_services/git_services/init/errors.py
+++ b/git_services/git_services/init/errors.py
@@ -1,41 +1,41 @@
+import shutil
 import sys
 import traceback
+
+from git_services.init.config import config_from_env
 
 
 class GitCloneGenericError(Exception):
     """A generic error class that is the parent class of all API errors raised
     by the git clone module."""
-
-    default_exit_code = 200
-
-    def __init__(
-        self,
-        exit_code=default_exit_code,
-    ):
-        self.exit_code = exit_code
+    exit_code = 200
 
 
 class GitServerUnavailableError(GitCloneGenericError):
-    default_exit_code = 201
+    exit_code = 201
 
 
 class UnexpectedAutosaveFormatError(GitCloneGenericError):
-    default_exit_code = 202
+    exit_code = 202
 
 
 class NoDiskSpaceError(GitCloneGenericError):
-    default_exit_code = 203
+    exit_code = 203
 
 
 class BranchDoesNotExistError(GitCloneGenericError):
-    default_code = 204
+    exit_code = 204
 
 
 class GitSubmoduleError(GitCloneGenericError):
-    default_code = 205
+    exit_code = 205
 
 
 def handle_exception(exc_type, exc_value, exc_traceback):
+    # NOTE: To prevent restarts of a failing init container from producing ambiguous errors
+    # cleanup the repo after a failure so that a restart of the container produces the same error.
+    config = config_from_env()
+    shutil.rmtree(config.mount_path, ignore_errors=True)
     if issubclass(exc_type, GitCloneGenericError):
         # INFO: The process failed in a specific way that should be distinguished to the user.
         # The user can take action to correct the failure.


### PR DESCRIPTION
@Panaetius as mentioned in #1055 this will make the error codes properly surface all the way to the user.

Before in all cases the error code was the generic one that had no details.

Note that the target of this PR is your feature branch.