### PR TITLE
fix(app): s3 bucket location

### DIFF
--- a/renku_notebooks/api/schemas.py
+++ b/renku_notebooks/api/schemas.py
@@ -78,7 +78,9 @@ class LaunchNotebookRequestS3mount(Schema):
 
     access_key = fields.Str(required=False, missing=None)
     secret_key = fields.Str(required=False, missing=None)
-    endpoint = fields.Str(required=True, validate=validate.Length(min=1))
+    endpoint = fields.Url(
+        required=True, schemes=["http", "https"], relative=False, require_tld=True
+    )
     bucket = fields.Str(required=True, validate=validate.Length(min=1))
 
     @post_load


### PR DESCRIPTION
This fixes two problems we have recently seen with s3 buckets:

1. Boto3 can handle a missing location but datashim (that actually mounts the buckets) cannot. Boto3 is used to check if the bucket exists before things are handed over to datashim. That is why we did not initially catch this.
This is the issue reported in #1044. In there for example mounting the bucket `ursa-labs-taxi-data` located in `http://s3.us-east-2.amazonaws.com` would fail if the endpoint was specified as `http://s3.amazonaws.com`. But this failure would occur in datashim and the API would not know about it. With this fix the API can catch these cases and not launch the session. The reason for this is that if the location is not specified in the url then the default is `us-east-1`. But when the location is omitted from the url and the bucket location is actually not `us-east-1` then datashim could not mount the bucket.

2. The endpoint has to be a regular http:// or https:// url. Passing in the hostname only or something else that is malformed does not. Marshmallow (which we already use for validation) already provides a field like this so we get the checks for free. Before any string was allowed.

closes #1044 