### PR TITLE
fix(app): custom certs env variables in git clone

### DIFF
--- a/renku_notebooks/api/amalthea_patches/init_containers.py
+++ b/renku_notebooks/api/amalthea_patches/init_containers.py
@@ -64,6 +64,14 @@ def git_clone(server):
             "name": "SENTRY_RELEASE",
             "value": os.environ.get("SENTRY_RELEASE"),
         },
+        {
+            "name": "REQUESTS_CA_BUNDLE",
+            "value": etc_cert_volume_mount["mountPath"]
+        },
+        {
+            "name": "SSL_CERT_FILE",
+            "value": etc_cert_volume_mount["mountPath"]
+        },
     ]
     if type(server._user) is RegisteredUser:
         env += [


### PR DESCRIPTION
Unless specific env variables are passed in a container then python will ignore the system-level cert store and use its own cert store. With these env variables python uses the system cert store where the certificate bundle that includes any custom certs is added.