### PR TITLE
fix(app): no main pod in status when getting logs

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -472,10 +472,12 @@ class UserServer:
         if js is None:
             return None
         output = {}
-        pod_name = js["status"]["mainPod"]["name"]
-        all_containers = js["status"]["mainPod"]["status"].get(
+        pod_name = js.get("status", {}).get("mainPod", {}).get("name")
+        if not pod_name:
+            return None
+        all_containers = js["status"]["mainPod"].get("status", {}).get(
             "containerStatuses", []
-        ) + js["status"]["mainPod"]["status"].get("initContainerStatuses", [])
+        ) + js["status"]["mainPod"].get("status", {}).get("initContainerStatuses", [])
         for container in all_containers:
             container_name = container["name"]
             try:


### PR DESCRIPTION
This fixes an unhandled error that shows up in sentry:
https://sentry.dev.renku.ch/organizations/sentry/issues/339/?environment=renkulab&project=5

The error occurs in `renku_notebooks/api/classes/server.py` in get_logs at line 486. And it is a `KeyError` for `mainPod`.

With the `.get()` statements I added this should not happen again.