### PR TITLE
fix(app): cloudstorage in server_options schema

### DIFF
--- a/renku_notebooks/__init__.py
+++ b/renku_notebooks/__init__.py
@@ -31,7 +31,7 @@ from .api.schemas.servers_get import (
     ServersGetResponse,
 )
 from .api.schemas.logs import ServerLogs
-from .api.schemas.config_server_options import ServerOptionsChoices
+from .api.schemas.config_server_options import ServerOptionsEndpointResponse
 from .api.schemas.autosave import AutosavesList
 from .api.schemas.version import VersionResponse
 from .api.notebooks import (
@@ -148,7 +148,7 @@ def register_swagger(app):
     spec.components.schema("ServersGetRequest", schema=ServersGetRequest)
     spec.components.schema("ServersGetResponse", schema=ServersGetResponse)
     spec.components.schema("ServerLogs", schema=ServerLogs)
-    spec.components.schema("ServerOptionsChoices", schema=ServerOptionsChoices)
+    spec.components.schema("ServerOptionsEndpointResponse", schema=ServerOptionsEndpointResponse)
     spec.components.schema("AutosavesList", schema=AutosavesList)
     spec.components.schema("VersionResponse", schema=VersionResponse)
     # Register endpoints

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -33,7 +33,7 @@ from .auth import authenticated
 from .schemas.servers_post import LaunchNotebookRequest
 from .schemas.servers_get import NotebookResponse, ServersGetRequest, ServersGetResponse
 from .schemas.logs import ServerLogs
-from .schemas.config_server_options import ServerOptionsChoices
+from .schemas.config_server_options import ServerOptionsEndpointResponse
 from .schemas.autosave import AutosavesList
 from .schemas.version import VersionResponse
 from .classes.server import UserServer
@@ -306,12 +306,12 @@ def server_options(user):
           description: Server options such as CPU, memory, storage, etc.
           content:
             application/json:
-              schema: ServerOptionsChoices
+              schema: ServerOptionsEndpointResponse
       tags:
         - servers
     """
     # TODO: append image-specific options to the options json
-    return ServerOptionsChoices().dump(
+    return ServerOptionsEndpointResponse().dump(
         {
             **current_app.config["SERVER_OPTIONS_UI"],
             "cloudstorage": {

--- a/renku_notebooks/api/schemas/config_server_options.py
+++ b/renku_notebooks/api/schemas/config_server_options.py
@@ -103,3 +103,17 @@ class ServerOptionsDefaults(Schema):
     disk_request = ByteSizeField(required=True)
     lfs_auto_fetch = fields.Bool(required=True)
     gpu_request = GpuField(required=True)
+
+
+class CloudStorageServerOption(Schema):
+    """Used to indicate in the server_options endpoint which types of cloud storage is enabled."""
+
+    s3 = fields.Nested(
+        Schema.from_dict({"enabled": fields.Bool(required=True)})(),
+        required=True,
+    )
+
+
+class ServerOptionsEndpointResponse(ServerOptionsChoices):
+    """Used to serialize the server options sent out through the server_options endpoint."""
+    cloudstorage = fields.Nested(CloudStorageServerOption(), required=True)


### PR DESCRIPTION
With the recent refactoring of the schema definitions for the server_options endpoint, the section that indicates to the ui that s3 storage is enabled was accidentally removed.

This essentially "turns off" the option to use s3 buckets even on deployments that had this feature turns on.