### PR TITLE
fix(app): list autosaves only for the current user

### DIFF
--- a/renku_notebooks/api/classes/storage.py
+++ b/renku_notebooks/api/classes/storage.py
@@ -95,6 +95,8 @@ class AutosaveBranch(Autosave):
                 f"Invalid branch name {autosave_branch_name} for autosave branch."
             )
             return None
+        if match_res.group("username") != user.username:
+            return None
         return cls(
             user,
             namespace_project,


### PR DESCRIPTION
Autosave branches were listed incorrectly. This was occurring because there was no check if the autosave branch belonged to the user requesting to list all autosave branches or not.

The problem was further worsened because the UI could not even determine the validity of the autosave branches it was receiving. Which blocked the launching of new sessions