### PR TITLE
fix(app): handle endpoints for s3 not on AWS

### DIFF
--- a/renku_notebooks/api/classes/s3mount.py
+++ b/renku_notebooks/api/classes/s3mount.py
@@ -149,9 +149,11 @@ class S3mount:
             .get("HTTPHeaders", {})
             .get("x-amz-bucket-region")
         )
+        parsed_endpoint = urlparse(self.endpoint)
         if (
             amz_bucket_region
-            and urlparse(self.endpoint).netloc != "s3.amazonaws.com"
+            and parsed_endpoint.netloc.endswith("amazonaws.com")
+            and parsed_endpoint.netloc != "s3.amazonaws.com"
             and amz_bucket_region not in self.endpoint
         ):
             return False

--- a/renku_notebooks/api/schemas/cloud_storage.py
+++ b/renku_notebooks/api/schemas/cloud_storage.py
@@ -9,7 +9,9 @@ class LaunchNotebookRequestS3mount(Schema):
 
     access_key = fields.Str(required=False, load_default=None)
     secret_key = fields.Str(required=False, load_default=None)
-    endpoint = fields.Str(required=True, validate=validate.Length(min=1))
+    endpoint = fields.Url(
+        required=True, schemes=["http", "https"], relative=False, require_tld=True
+    )
     bucket = fields.Str(required=True, validate=validate.Length(min=1))
 
     @post_load


### PR DESCRIPTION
This logic was changed recently to recognize the amazon aws s3 region. It was done under the assumption that this `x-amz-bucket-region` would only show up for AWS s3 endpoints and not in other cases. But this is not true. This field can be present even if the bucket is not hosted on AWS. Because of this some buckets that truly exist and could be reached were deemed to not exist by the notebook service.

This corrects those problems.

/deploy #persist