### PR TITLE
chore: use CA certificates chart 0.0.3

### DIFF
--- a/helm-chart/renku-notebooks/requirements.yaml
+++ b/helm-chart/renku-notebooks/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
   version: "0.4.0"
 - name: certificates
-  version: "0.0.1"
+  version: "0.0.3"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
 - name: dlf-chart
   repository: "https://swissdatasciencecenter.github.io/datashim/"

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -18,7 +18,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: "0.0.1"
+      tag: "0.0.2"
     customCAs:
       []
       # - secret:


### PR DESCRIPTION
Update the helm chart used to insert self-signed CA certificates to the latest version. This latest version can run as non-root.

/deploy #persist