### PR TITLE
fix(app): listing autosaves and debug statements

### DIFF
--- a/renku_notebooks/api/auth.py
+++ b/renku_notebooks/api/auth.py
@@ -32,7 +32,6 @@ def authenticated(f):
 
     @wraps(f)
     def decorated(*args, **kwargs):
-        current_app.logger.debug(f"Getting headers, {list(request.headers.keys())}")
         user = RegisteredUser(request.headers)
         if current_app.config["ANONYMOUS_SESSIONS_ENABLED"] and not user.authenticated:
             user = AnonymousUser(request.headers)

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -70,7 +70,7 @@ class AnonymousUser(User):
         if not self.authenticated:
             return
         self.git_url = current_app.config["GITLAB_URL"]
-        self.gitlab_client = Gitlab(self.git_url, api_version=4)
+        self.gitlab_client = Gitlab(self.git_url, api_version=4, per_page=50)
         self.username = headers[self.auth_header]
         self.safe_username = escapism.escape(self.username, escape_char="-").lower()
         self.full_name = None
@@ -117,6 +117,7 @@ class RegisteredUser(User):
             self.git_url,
             api_version=4,
             oauth_token=self.git_token,
+            per_page=50,
         )
         self.setup_k8s()
 
@@ -158,12 +159,14 @@ class RegisteredUser(User):
         autosaves = []
         # add any autosave branches, regardless of wheter pvcs are supported or not
         if namespace_project is None:  # get autosave branches from all projects
-            projects = self.gitlab_client.projects.list()
+            projects = self.gitlab_client.projects.list(iterator=True)
         elif gl_project:
             projects.append(gl_project)
         for project in projects:
             try:
-                branches = project.branches.list(search="^renku/autosave/")
+                branches = project.branches.list(
+                    search="^renku/autosave/", iterator=True
+                )
             except GitlabListError:
                 branches = []
             for branch in branches:
@@ -174,7 +177,7 @@ class RegisteredUser(User):
                     autosaves.append(autosave)
                 else:
                     current_app.logger.warning(
-                        "Autosave branch {branch} for "
+                        f"Autosave branch {branch} for "
                         f"{namespace_project} cannot be instantiated."
                     )
         return autosaves

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,7 +98,10 @@ def base_url():
 @pytest.fixture(scope="session")
 def registered_gitlab_client():
     client = Gitlab(
-        os.environ["GITLAB_URL"], api_version=4, oauth_token=os.environ["GITLAB_TOKEN"]
+        os.environ["GITLAB_URL"],
+        api_version=4,
+        oauth_token=os.environ["GITLAB_TOKEN"],
+        per_page=50,
     )
     client.auth()
     return client
@@ -106,7 +109,7 @@ def registered_gitlab_client():
 
 @pytest.fixture(scope="session")
 def anonymous_gitlab_client():
-    client = Gitlab(os.environ["GITLAB_URL"], api_version=4)
+    client = Gitlab(os.environ["GITLAB_URL"], api_version=4, per_page=50)
     return client
 
 
@@ -465,7 +468,7 @@ def create_remote_branch(registered_gitlab_client, gitlab_project):
 
     for branch in created_branches:
         project = registered_gitlab_client.projects.get(branch.project_id)
-        pipelines = project.pipelines.list()
+        pipelines = project.pipelines.list(iterator=True)
         for pipeline in pipelines:
             if pipeline.sha == branch.commit["id"] and pipeline.ref == branch.name:
                 pipeline.cancel()


### PR DESCRIPTION
Fixes minor issues with debug statements (some of which are useless but occur way to frequently).

And also with gitlab pagination when there are a lot of items to be listed. If the `iterator` option is used when listing things then the api handles the pagination seamlessly in the generator.

Depends on #1146 