### PR TITLE
chore: use 'sub' JWT field for user id

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -620,6 +620,7 @@ class UserServer:
             f"{prefix}gitlabProjectId": None,
             f"{prefix}safe-username": self._user.safe_username,
             f"{prefix}username": self._user.username,
+            f"{prefix}userId": self._user.id,
             f"{prefix}servername": self.server_name,
             f"{prefix}branch": self.branch,
             f"{prefix}git-host": self.git_host,

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -74,10 +74,10 @@ class AnonymousUser(User):
         self.username = headers[self.auth_header]
         self.safe_username = escapism.escape(self.username, escape_char="-").lower()
         self.full_name = None
-        self.keycloak_user_id = None
         self.email = None
         self.oidc_issuer = None
         self.git_token = None
+        self.id = headers[self.auth_header]
         self.setup_k8s()
 
     def get_autosaves(self, *args, **kwargs):
@@ -101,12 +101,12 @@ class RegisteredUser(User):
         if not self.authenticated:
             return
         parsed_id_token = self.parse_jwt_from_headers(headers)
-        self.keycloak_user_id = parsed_id_token["sub"]
         self.email = parsed_id_token["email"]
         self.full_name = parsed_id_token["name"]
         self.username = parsed_id_token["preferred_username"]
         self.safe_username = escapism.escape(self.username, escape_char="-").lower()
         self.oidc_issuer = parsed_id_token["iss"]
+        self.id = parsed_id_token["sub"]
 
         (
             self.git_url,


### PR DESCRIPTION
This adds an `id` field to the user class.

The field is the keycloak user ID for registered user and for anonymous users it is the unique id that the gateway generates.

These are added in the annotations so that they can be used in publishing metrics. Currently the only user-identifying property we have is the email. But the id is better to use in logging or metrics because it better protects the user's privacy.

Also the `keycloak_user_id` field is removed because it is not used anywhere and anonymous users are not in keycloak.