### PR TITLE
feat(app): add session url env var

### DIFF
--- a/renku_notebooks/api/amalthea_patches/jupyter_server.py
+++ b/renku_notebooks/api/amalthea_patches/jupyter_server.py
@@ -51,6 +51,11 @@ def env(server: "UserServer"):
         {
             "op": "add",
             "path": "/statefulset/spec/template/spec/containers/0/env/-",
+            "value": {"name": "SESSION_URL", "value": server.server_url},
+        },
+        {
+            "op": "add",
+            "path": "/statefulset/spec/template/spec/containers/0/env/-",
             "value": {"name": "PROJECT_NAME", "value": server.project},
         },
         {

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -502,7 +502,7 @@ class UserServer:
         return output
 
     @property
-    def server_url(self):
+    def server_url(self) -> str:
         """The URL where a user can access their session."""
         if type(self._user) is RegisteredUser:
             return urljoin(
@@ -618,6 +618,7 @@ class UserServer:
             "CI_COMMIT_SHA",
             "NOTEBOOK_DIR",
             "MOUNT_PATH",
+            "SESSION_URL",
             "PROJECT_NAME",
             "GIT_CLONE_REPO",
         ]

--- a/renku_notebooks/config/__init__.py
+++ b/renku_notebooks/config/__init__.py
@@ -42,9 +42,9 @@ def get_config(default_config: str) -> _NotebooksConfig:
 
     If the "CONFIG_FILE" environment variable is set then that file is read and used.
     The values from the file can be overridden by environment variables that start with
-    "NB_" followed by the appropirate name. Refer to the dataconf documentation about
+    "NB_" followed by the appropriate name. Refer to the dataconf documentation about
     how to set nested or list values. Although more complicated values are more easily set through
-    a config file than envirionment variables.
+    a config file than environment variables.
     """
     config_file = os.getenv("CONFIG_FILE")
     config = dataconf.multi.string(default_config)

--- a/renku_notebooks/util/kubernetes_.py
+++ b/renku_notebooks/util/kubernetes_.py
@@ -72,7 +72,7 @@ def make_server_name(
     else:
         # NOTE: Username starts with an invalid character. This has to be modified because a
         # k8s service object cannot start with anything other than a lowercase alphabet character.
-        # NOTE: We do not have worry about collisions with already exsiting servers from older
+        # NOTE: We do not have worry about collisions with already existing servers from older
         # versions because the server name includes the hash of the original username, so the hash
         # would be different because the original username differs between someone whose username
         # is for example 7User vs. n7User.


### PR DESCRIPTION
Adds a `SESSION_URL` env var that shows full session's url.

Fixes: #1152 

/deploy #persist