### PR TITLE
fix(sidecar): use fetch before running git status

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -21,8 +21,7 @@ ENV PATH=$PATH:/home/kyaku/.renku/bin
 RUN mkdir -p /home/kyaku/.renku/bin && \
     virtualenv /home/kyaku/.renku/venv && \
     . /home/kyaku/.renku/venv/bin/activate && \
-    pip install --no-cache-dir setuptools==57.5.0 && \
-    pip install --no-cache renku==0.16.1 && \
+    pip install --no-cache renku && \
     deactivate && \
     ln -s /home/kyaku/.renku/venv/bin/renku /home/kyaku/.renku/bin/renku
 

--- a/git_services/git_services/sidecar/commands/base.py
+++ b/git_services/git_services/sidecar/commands/base.py
@@ -28,6 +28,7 @@ def status(path: Path):
         'status': string with the 'raw' result from running git status in the repository
     """
     cli = GitCLI(path)
+    cli.git_fetch()
     status = cli.git_status("--porcelain=v2 --branch")
 
     repo_clean = True


### PR DESCRIPTION
We should fetch before we run `git status` in the json rpc sidecar.