### PR TITLE
fix(chart): template PVC sessions flag properly

### DIFF
--- a/helm-chart/renku-notebooks/templates/statefulset.yaml
+++ b/helm-chart/renku-notebooks/templates/statefulset.yaml
@@ -33,9 +33,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:
-            {{ if .Values.userSessionPersistentVolumes.enabled }}
             - name: NB_SESSIONS__STORAGE__PVS_ENABLED
               value: {{ .Values.userSessionPersistentVolumes.enabled | quote }}
+            {{ if .Values.userSessionPersistentVolumes.enabled }}
             - name: NB_SESSIONS__STORAGE__PVS_STORAGE_CLASS
               value: {{ .Values.userSessionPersistentVolumes.storageClass | quote}}
             {{ end }}


### PR DESCRIPTION
The flag that enables/disables the use of PVCs for user sessions was templated only when the corresponding value in the values file was set to "true". Because of this when the value was set to false the environment variable was not templated at all and the default value if the environment variable is missing is "true". This means that it was impossible to use EmptyDir in sessions.