### PR TITLE
feat(app): detailed status messages

### DIFF
--- a/helm-chart/renku-notebooks/requirements.yaml
+++ b/helm-chart/renku-notebooks/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: amalthea
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
-  version: "0.5.2"
+  version: "0.6.0"
 - name: certificates
   version: "0.0.3"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/renku_notebooks/api/amalthea_patches/general.py
+++ b/renku_notebooks/api/amalthea_patches/general.py
@@ -83,10 +83,13 @@ def test(server: "UserServer"):
     to fail if the test statements are not correct. This is used to ensure that the
     order of containers in the amalthea manifests is what the notebook service expects."""
     patches = []
+    # NOTE: Only the first 1 or 2 containers come "included" from Amalthea, the rest are patched in
+    # This tests checks whether the expected number and order is received from Amalthea and
+    # does not use all containers.
     container_names = (
-        config.sessions.container_order_registered
+        config.sessions.containers.registered[:2]
         if type(server._user) is RegisteredUser
-        else config.sessions.container_order_anonymous
+        else config.sessions.containers.anonymous[:1]
     )
     for container_ind, container_name in enumerate(container_names):
         patches.append(

--- a/renku_notebooks/api/amalthea_patches/init_containers.py
+++ b/renku_notebooks/api/amalthea_patches/init_containers.py
@@ -173,3 +173,25 @@ def certificates():
         },
     ]
     return patches
+
+
+def download_image(server: "UserServer"):
+    container = client.V1Container(
+        name="download-image",
+        image=server.verified_image,
+        command=["sh", "-c"],
+        args=["exit", "0"],
+    )
+    api_client = client.ApiClient()
+    return [
+        {
+            "type": "application/json-patch+json",
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/statefulset/spec/template/spec/initContainers/-",
+                    "value": api_client.sanitize_for_serialization(container),
+                },
+            ],
+        },
+    ]

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -293,6 +293,7 @@ class UserServer:
                 # init container for certs must come before all other init containers
                 # so that it runs first before all other init containers
                 init_containers_patches.certificates(),
+                init_containers_patches.download_image(self),
                 init_containers_patches.git_clone(self),
                 inject_certificates_patches.proxy(self),
             )

--- a/renku_notebooks/config/__init__.py
+++ b/renku_notebooks/config/__init__.py
@@ -113,6 +113,19 @@ sessions {
     storage {
         pvs_enabled: true
     }
+    containers {
+        anonymous = [
+            jupyter-server,
+            passthrough-proxy,
+            git-proxy,
+        ]
+        registered = [
+            jupyter-server,
+            oauth2-proxy,
+            git-proxy,
+            git-sidecar,
+        ]
+    }
     enforce_cpu_limits: false
     autosave_minimum_lfs_file_size_bytes: 1000000
     termination_grace_period_seconds: 600
@@ -120,13 +133,6 @@ sessions {
     node_selector: "{}"
     affinity: "{}"
     tolerations: "[]"
-    container_order_anonymous = [
-        jupyter-server
-    ]
-    container_order_registered = [
-        jupyter-server
-        oauth2-proxy
-    ]
 }
 amalthea {
     group = amalthea.dev

--- a/renku_notebooks/config/dynamic.py
+++ b/renku_notebooks/config/dynamic.py
@@ -173,6 +173,12 @@ class _SessionCullingConfig:
 
 
 @dataclass
+class _SessionContainers:
+    anonymous: List[Text]
+    registered: List[Text]
+
+
+@dataclass
 class _SessionConfig:
     culling: _SessionCullingConfig
     git_proxy: _GitProxyConfig
@@ -182,6 +188,7 @@ class _SessionConfig:
     ca_certs: _CustomCaCertsConfig
     oidc: _SessionOidcConfig
     storage: _SessionStorageConfig
+    containers: _SessionContainers
     default_image: Text = "renku/singleuser:latest"
     enforce_cpu_limits: Union[Text, bool] = False
     autosave_minimum_lfs_file_size_bytes: Union[int, Text] = 1000000
@@ -190,15 +197,11 @@ class _SessionConfig:
     node_selector: Text = "{}"
     affinity: Text = "{}"
     tolerations: Text = "[]"
-    container_order_anonymous: List[Text] = field(
+    init_containers: List[Text] = field(
         default_factory=lambda: [
-            "jupyter-server",
-        ]
-    )
-    container_order_registered: List[Text] = field(
-        default_factory=lambda: [
-            "jupyter-server",
-            "oauth2-proxy",
+            "init-certificates",
+            "download-image",
+            "git-clone",
         ]
     )
 


### PR DESCRIPTION
closes #1135 

Provides more detailed information about server status.

Example status section of server response:
```json
                         "status": {
				"details": [{  # NEW
					"status": "ready",
					"step": "Initialization"
				}, {
					"status": "ready",
					"step": "Downloading session image"
				}, {
					"status": "executing",
					"step": "Cloning and configuring the repository"
				}, {
					"status": "waiting",
					"step": "Git credentials services"
				}, {
					"status": "waiting",
					"step": "Authentication and proxying services"
				}, {
					"status": "waiting",
					"step": "Auxiliary session services"
				}, {
					"status": "waiting",
					"step": "Starting session"
				}],
				"message": "Containers with non-ready statuses: git-proxy, git-sidecar, jupyter-server, oauth2-proxy.",
				"readyNumContainers": 2,  # NEW
				"state": "starting",
				"totalNumContainers": 7  # NEW
			},
```

Possible step states:
- ready
- executing
- waiting
- failed

Because of how containers react in k8s I modified the terminology a little bit. A container can be ready if it completes with 0 exit code or if it run and it passes all its probes. When all containers (i.e. steps) are ready then the whole session is ready. But the definitive flag on when the session can be accessed and is 100% ready is the `status.state` value. The `status.state` value will even check if the URL is reachable before turning to "running".

/deploy #persist