### PR TITLE
fix(sidecar): renku needs to be on path

### DIFF
--- a/git_services/Dockerfile.sidecar
+++ b/git_services/Dockerfile.sidecar
@@ -1,5 +1,5 @@
 FROM python:3.9-alpine as base
-RUN apk add --no-cache git git-lfs curl tini && \
+RUN apk add --no-cache git git-lfs curl tini bash && \
     adduser jovyan -u1000 -g100 --disabled-password
 WORKDIR /git_services
 
@@ -19,5 +19,6 @@ LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
 USER 1000:1000
 COPY --from=builder /git_services ./
 ADD git_services ./git_services
+ENV PATH="${PATH}:/git_services/.venv/bin"
 ENTRYPOINT ["tini", "-g", "--"]
 CMD [".venv/bin/gunicorn", "-c", "git_services/sidecar/gunicorn.conf.py"]

--- a/git_services/git_services/sidecar/errors.py
+++ b/git_services/git_services/sidecar/errors.py
@@ -11,29 +11,34 @@ from git_services.cli import GitCommandError
 @dataclass
 class SidecarGenericError(Exception):
     """Base class for all sidecar error."""
+
     message: str = "Something went wrong"
 
 
 @dataclass
 class SidecarUserError(SidecarGenericError):
     """An error that can be corrected by the user."""
+
     message: str
 
 
 @dataclass
 class SidecarProgrammingError(SidecarGenericError):
     """An error that can not be corrected by the user, usually a bug."""
+
     pass
 
 
 class JSONRPCGenericError(JSONRPCDispatchException):
     """Base class for all JSON RPC errors."""
+
     def __init__(self, code=-32603, message="Something went wrong", data=None, *args, **kwargs):
         super().__init__(code, message, data, *args, **kwargs)
 
 
 class JSONRPCProgrammingError(JSONRPCDispatchException):
     """An error that cannot be corrected by the user the RPC server."""
+
     def __init__(self, code=-32000, message="Something went wrong", data=None, *args, **kwargs):
         super().__init__(code, message, data, *args, **kwargs)
 
@@ -43,24 +48,29 @@ class JSONRPCUserError(JSONRPCDispatchException):
 
     Usually involves sending invalid parameters or requesting resources that do not exist.
     """
+
     def __init__(self, code=-32001, message=None, data=None, *args, **kwargs):
         super().__init__(code, message, data, *args, **kwargs)
 
 
 def json_rpc_errors(func):
     """Convert errors to predictable JSON-RPC format."""
+
     @functools.wraps(func)
     def _json_rpc_errors(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except JSONRPCDispatchException:
+        except JSONRPCDispatchException as e:
+            logging.exception(e)
             raise
         except SidecarGenericError as e:
+            logging.exception(e)
             if isinstance(e, SidecarUserError):
                 raise JSONRPCUserError(message=e.message)
             else:
                 raise JSONRPCProgrammingError(message=e.message)
         except RenkuException as e:
+            logging.exception(e)
             raise JSONRPCProgrammingError(
                 message=getattr(
                     e,
@@ -70,6 +80,7 @@ def json_rpc_errors(func):
                 )
             )
         except GitCommandError as e:
+            logging.exception(e)
             raise JSONRPCProgrammingError(
                 message=f"Running a git command failed with the error: {e.stderr}",
             )


### PR DESCRIPTION
There were some issues running renku cli commands from within the git rpc sidecar.

These were the result of:
- the python git library used by renku trying to use `bash` and the alpine images not having `bash` by default, after installing bash in the image (which added only 1MB to the size) I did not see this again
- the renku cli not being on the path - after I adjusted the path for the image everything works

cc @ciyer 