### PR TITLE
fix: poetry flags not parsed properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ WORKDIR /home/kyaku/renku-notebooks
 
 FROM base as builder
 ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VIRTUALENVS_IN_PROJECT=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_SETUPTOOLS=true
 COPY poetry.lock pyproject.toml ./
 RUN apk add --no-cache alpine-sdk libffi-dev && \
     mkdir -p /opt/poetry && \
     curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.1 python3 - && \
+    /opt/poetry/bin/poetry config virtualenvs.in-project true  && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-setuptools true && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-pip true  && \
     /opt/poetry/bin/poetry install --only main --no-root
 
 FROM base as runtime

--- a/git_services/Dockerfile.init
+++ b/git_services/Dockerfile.init
@@ -5,13 +5,13 @@ WORKDIR /git_services
 
 FROM base as builder
 ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VIRTUALENVS_IN_PROJECT=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_SETUPTOOLS=true
 COPY pyproject.toml poetry.lock ./
 RUN apk add --no-cache alpine-sdk linux-headers && \
     mkdir -p /opt/poetry && \
     curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.1 python3 - && \
+    /opt/poetry/bin/poetry config virtualenvs.in-project true  && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-setuptools true && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-pip true  && \
     /opt/poetry/bin/poetry install --only main --no-root
 
 FROM base as runtime

--- a/git_services/Dockerfile.sidecar
+++ b/git_services/Dockerfile.sidecar
@@ -5,13 +5,13 @@ WORKDIR /git_services
 
 FROM base as builder
 ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VIRTUALENVS_IN_PROJECT=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true
-ENV POETRY_VIRTUALENVS_OPTIONS_NO_SETUPTOOLS=true
 COPY pyproject.toml poetry.lock ./
 RUN apk add --no-cache alpine-sdk linux-headers && \
     mkdir -p /opt/poetry && \
     curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.1 python3 - && \
+    /opt/poetry/bin/poetry config virtualenvs.in-project true  && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-setuptools true && \
+    /opt/poetry/bin/poetry config virtualenvs.options.no-pip true  && \
     /opt/poetry/bin/poetry install --only main --no-root
 
 FROM base as runtime


### PR DESCRIPTION
Poetry 1.2.0 seems to have a bug where the settings set in environment variables are not parsed correctly and not really respected.

For example none of the images built are supposed to come with pip and setuptools. But both can be found in them.

If the settings are applied through `poetry config <config name> <value>` then pip and setuptools are truly excluded as originally intended. 

This has no real consequences other than keeping docker image size small.

/deploy #persist