### PR TITLE
fix: handle expiring gitlab tokens in sessions

### DIFF
--- a/git-https-proxy/Dockerfile
+++ b/git-https-proxy/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.18.0-alpine3.15 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 COPY . /src
 WORKDIR /src
-RUN go build -o /git-http-proxy main.go 
+RUN go build -o /git-http-proxy
 
 FROM alpine:3.16
 COPY --from=builder /git-http-proxy /git-http-proxy

--- a/git-https-proxy/config/config.go
+++ b/git-https-proxy/config/config.go
@@ -1,0 +1,179 @@
+// Package config stores the configuration for a git proxy.
+// It also manages and refreshes the renku and git oauth tokens it stores.
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type GitProxyConfig struct {
+	// The port where the proxy is listening on
+	ProxyPort string
+	// The port (separate from the proxy) where the proxy will respond to status probes
+	HealthPort string
+	// True if this is an anonymous seession
+	AnonymousSession bool
+	// The Git oauth token injected in Git requests by the proxy - not guaranteed to be a JWT.
+	// Gitlab oauth tokens are not JWT tokens.
+	gitOauthToken string
+	// The unix epoch timestamp (in seconds) when the Git Oauth token expires
+	gitOauthTokenExpiresAt int64
+	// The JWT oauth token issued by Keycloak to a logged in Renku user
+	renkuJWT string
+	// The URL of the project repository for the session
+	RepoURL *url.URL
+	// The url of the renku deployment
+	RenkuURL *url.URL
+	// How long should the proxy wait for a shutdown signal from the main session container
+	// before it shuts down. This is needed because the git-proxy needs to wait for the session
+	// to shutdown first. Because if the session wants to create an autosave branch but if the
+	// proxy has already shut down then creating the autosave branch will fail and the unsaved
+	// work from the session will be irrecoverably lost,
+	SessionTerminationGracePeriod time.Duration
+	// Used when the Git oauth token is refreshed. Ensures that the token is not refereshed
+	// twice at the same time. It also ensures that all other threads that need to simply
+	// read the token will wait until the refresh (write) is complete.
+	gitTokenLock *sync.RWMutex
+	renkuJWTLock *sync.RWMutex
+}
+
+// Parse the environment variables used as the configuration for the proxy.
+func ParseEnv() GitProxyConfig {
+	var ok, anonymousSession bool
+	var gitOauthToken, proxyPort, healthPort, anonymousSessionStr, SessionTerminationGracePeriodSeconds, renkuJWT, renkuURL, gitOauthTokenExpiresAtRaw string
+	var repoURL *url.URL
+	var err error
+	var gitOauthTokenExpiresAt int64
+	var SessionTerminationGracePeriod time.Duration
+	if proxyPort, ok = os.LookupEnv("GIT_PROXY_PORT"); !ok {
+		proxyPort = "8080"
+	}
+	if healthPort, ok = os.LookupEnv("GIT_PROXY_HEALTH_PORT"); !ok {
+		healthPort = "8081"
+	}
+	if anonymousSessionStr, ok = os.LookupEnv("ANONYMOUS_SESSION"); !ok {
+		anonymousSessionStr = "true"
+	}
+	anonymousSession = anonymousSessionStr == "true"
+	if SessionTerminationGracePeriodSeconds, ok = os.LookupEnv("SESSION_TERMINATION_GRACE_PERIOD_SECONDS"); !ok {
+		SessionTerminationGracePeriodSeconds = "600"
+	}
+	SessionTerminationGracePeriodSeconds = fmt.Sprintf("%ss", SessionTerminationGracePeriodSeconds)
+	SessionTerminationGracePeriod, err = time.ParseDuration(SessionTerminationGracePeriodSeconds)
+	if err != nil {
+		log.Fatalf("Cannot parse 'SESSION_TERMINATION_GRACE_PERIOD_SECONDS' %s: %s\n", SessionTerminationGracePeriodSeconds, err.Error())
+	}
+	if renkuJWT, ok = os.LookupEnv("RENKU_JWT"); !ok {
+		log.Fatal("Cannot find required 'RENKU_JWT' environment variable\n")
+	}
+	if gitOauthToken, ok = os.LookupEnv("GITLAB_OAUTH_TOKEN"); !ok {
+		log.Fatal("Cannot find required 'GITLAB_OAUTH_TOKEN' environment variable\n")
+	}
+	if gitOauthTokenExpiresAtRaw, ok = os.LookupEnv("GITLAB_OAUTH_TOKEN_EXPIRES_AT"); !ok {
+		log.Fatal("Cannot find required 'GITLAB_OAUTH_TOKEN_EXPIRES_AT' environment variable\n")
+	}
+	if gitOauthTokenExpiresAt, err = strconv.ParseInt(gitOauthTokenExpiresAtRaw, 10, 64); err != nil {
+		log.Fatalf("Cannot convert 'GITLAB_OAUTH_TOKEN_EXPIRES_AT' environment variable %s to integer\n", gitOauthTokenExpiresAtRaw)
+	}
+	repoURL, err = url.Parse(os.Getenv("REPOSITORY_URL"))
+	if err != nil {
+		log.Fatalf("Cannot parse 'REPOSITORY_URL': %s", err.Error())
+	}
+	if renkuURL, ok = os.LookupEnv("RENKU_URL"); !ok {
+		log.Fatal("Cannot find required 'RENKU_URL' environment variable\n")
+	}
+	parsedRenkuURL, err := url.Parse(renkuURL)
+	if err != nil {
+		log.Fatalf("Cannot parse 'RENKU_URL' %s: %s", renkuURL, err.Error())
+	}
+	return GitProxyConfig{
+		ProxyPort:                     proxyPort,
+		HealthPort:                    healthPort,
+		AnonymousSession:              anonymousSession,
+		gitOauthToken:                 gitOauthToken,
+		gitOauthTokenExpiresAt:        gitOauthTokenExpiresAt,
+		renkuJWT:                      renkuJWT,
+		RepoURL:                       repoURL,
+		RenkuURL:                      parsedRenkuURL,
+		SessionTerminationGracePeriod: SessionTerminationGracePeriod,
+		gitTokenLock:                  &sync.RWMutex{},
+		renkuJWTLock:                  &sync.RWMutex{},
+	}
+}
+
+func (c *GitProxyConfig) GetRenkuJWT() string {
+	c.renkuJWTLock.RLock()
+	defer c.renkuJWTLock.RUnlock()
+	return c.renkuJWT
+}
+
+func (c *GitProxyConfig) GetGitOauthToken(encode bool) (string, error) {
+	if time.Now().Unix() >= c.gitOauthTokenExpiresAt+30 {
+		log.Println("Refreshing git token")
+		err := c.refreshOauthTokens()
+		if err != nil {
+			return "", err
+		}
+	}
+	c.gitTokenLock.RLock()
+	defer c.gitTokenLock.RUnlock()
+	if encode {
+		return encodeGitCredentials(c.gitOauthToken), nil
+	}
+	return c.gitOauthToken, nil
+}
+
+func encodeGitCredentials(token string) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("oauth2:%s", token)))
+}
+
+type tokenRefreshResponse struct {
+	Git struct {
+		AccessToken string `json:"access_token"`
+		ExpiresAt   int64  `json:"expires_at"`
+	}
+	Renku struct {
+		AccessToken string `json:"access_token"`
+	}
+}
+
+// Exchange the keycloak oauth token for a gitlab token
+// The gateway will also refresh the keycloak token and return a new
+// one if it is expired.
+func (c *GitProxyConfig) refreshOauthTokens() (err error) {
+	c.gitTokenLock.Lock()
+	c.renkuJWTLock.Lock()
+	defer c.gitTokenLock.Unlock()
+	defer c.renkuJWTLock.Unlock()
+	req, err := http.NewRequest(http.MethodPost, c.RenkuURL.JoinPath("api/auth/gitlab/exchange").String(), nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.renkuJWT))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("cannot exchange keycloak oauth token for git token, failed with staus code: %d", res.StatusCode)
+		return
+	}
+	var resParsed tokenRefreshResponse
+	err = json.NewDecoder(res.Body).Decode(&resParsed)
+	if err != nil {
+		return
+	}
+	c.gitOauthToken = resParsed.Git.AccessToken
+	c.renkuJWT = resParsed.Renku.AccessToken
+	c.gitOauthTokenExpiresAt = resParsed.Git.ExpiresAt
+	return nil
+}

--- a/git-https-proxy/config/config.go
+++ b/git-https-proxy/config/config.go
@@ -154,7 +154,7 @@ func (c *GitProxyConfig) refreshOauthTokens() (err error) {
 	c.renkuJWTLock.Lock()
 	defer c.gitTokenLock.Unlock()
 	defer c.renkuJWTLock.Unlock()
-	req, err := http.NewRequest(http.MethodPost, c.RenkuURL.JoinPath("api/auth/gitlab/exchange").String(), nil)
+	req, err := http.NewRequest(http.MethodGet, c.RenkuURL.JoinPath("api/auth/gitlab/exchange").String(), nil)
 	if err != nil {
 		return
 	}

--- a/git-https-proxy/config/config_test.go
+++ b/git-https-proxy/config/config_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestConfig(renkuUrl string, gitToken string, gitTokenExpiresAt int64, renkuToken string) GitProxyConfig {
+	os.Setenv("GITLAB_OAUTH_TOKEN", gitToken)
+	defer os.Unsetenv("GITLAB_OAUTH_TOKEN")
+	os.Setenv("GITLAB_OAUTH_TOKEN_EXPIRES_AT", fmt.Sprintf("%d", gitTokenExpiresAt))
+	defer os.Unsetenv("GITLAB_OAUTH_TOKEN_EXPIRES_AT")
+	os.Setenv("RENKU_JWT", renkuToken)
+	defer os.Unsetenv("RENKU_JWT")
+	os.Setenv("RENKU_URL", renkuUrl)
+	defer os.Unsetenv("RENKU_URL")
+	os.Setenv("REPOSITORY_URL", "https://dummy.renku.com")
+	defer os.Unsetenv("REPOSITORY_URL")
+	os.Setenv("ANONYMOUS_SESSION", "false")
+	defer os.Unsetenv("ANONYMOUS_SESSION")
+	return ParseEnv()
+}
+
+func setUpTestServer(handler http.Handler) (*url.URL, func()) {
+	ts := httptest.NewServer(handler)
+	tsUrl, err := url.Parse(ts.URL)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return tsUrl, ts.Close
+}
+
+func setUpAuthServer(refreshResponse *tokenRefreshResponse) (*url.URL, func()) {
+	handler := http.NewServeMux()
+	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Handling refresh token request")
+		if refreshResponse == nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Cannot refresh token"))
+		}
+		json.NewEncoder(w).Encode(refreshResponse)
+	}
+	handler.HandleFunc("/", handlerFunc)
+	return setUpTestServer(handler)
+}
+
+func TestSuccessfulRefresh(t *testing.T) {
+	newGitToken := "newGitToken"
+	newRenkuToken := "newRenkuToken"
+	refreshResponse := &tokenRefreshResponse{
+		Git: struct {
+			AccessToken string `json:"access_token"`
+			ExpiresAt   int64  `json:"expires_at"`
+		}{
+			AccessToken: newGitToken,
+			ExpiresAt:   time.Now().Unix() + 999999999999,
+		},
+		Renku: struct {
+			AccessToken string `json:"access_token"`
+		}{
+			AccessToken: newRenkuToken,
+		},
+	}
+	authServerURL, authServerClose := setUpAuthServer(refreshResponse)
+	defer authServerClose()
+
+	// token refresh is needed and succeeds
+	config := getTestConfig(authServerURL.String(), "oldGitToken", time.Now().Unix()-9999999, "oldRenkuToken")
+	gitToken, err := config.GetGitOauthToken(false)
+	assert.Nil(t, err)
+	assert.Equal(t, gitToken, newGitToken)
+	assert.Equal(t, config.GetRenkuJWT(), newRenkuToken)
+
+	// change token in server response
+	// assert that immediately after the refresh the token is valid and is not refreshed again
+	refreshResponse.Git.AccessToken = "SomethingElse"
+	refreshResponse.Renku.AccessToken = "SomethingElse"
+	gitToken, err = config.GetGitOauthToken(false)
+	assert.Nil(t, err)
+	assert.Equal(t, gitToken, newGitToken)
+	assert.Equal(t, config.GetRenkuJWT(), newRenkuToken)
+}
+
+func TestNoRefreshNeeded(t *testing.T) {
+	oldGitToken := "oldGitToken"
+	oldRenkuToken := "oldRenkuToken"
+	authServerURL, authServerClose := setUpAuthServer(nil)
+	defer authServerClose()
+
+	config := getTestConfig(authServerURL.String(), oldGitToken, time.Now().Unix()+99999, oldRenkuToken)
+	gitToken, err := config.GetGitOauthToken(false)
+	assert.Nil(t, err)
+	assert.Equal(t, gitToken, oldGitToken)
+	assert.Equal(t, config.GetRenkuJWT(), oldRenkuToken)
+}

--- a/git-https-proxy/go.mod
+++ b/git-https-proxy/go.mod
@@ -1,6 +1,6 @@
-module SwissDataScienceCenter/renku-notebooks/git-https-proxy
+module github.com/SwissDataScienceCenter/renku-notebooks/git-https-proxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20220328115640-894aeddb713e

--- a/git-https-proxy/main.go
+++ b/git-https-proxy/main.go
@@ -154,7 +154,10 @@ func getProxyHandler(config configLib.GitProxyConfig) *goproxy.ProxyHttpServer {
 			return r, nil
 		}
 		if !validGitRequest {
-			log.Printf("The request %s does not match the git repository %s letting request through without adding auth headers\n", r.URL.String(), config.RepoURL.String())
+			// Skip logging healthcheck requests
+			if r.URL.Path != "/ping" && r.URL.Path != "/ping/" {
+				log.Printf("The request %s does not match the git repository %s letting request through without adding auth headers\n", r.URL.String(), config.RepoURL.String())
+			}
 			return r, nil
 		}
 		log.Printf("The request %s matches the git repository %s, adding auth headers\n", r.URL.String(), config.RepoURL.String())

--- a/renku_notebooks/api/amalthea_patches/git_proxy.py
+++ b/renku_notebooks/api/amalthea_patches/git_proxy.py
@@ -47,7 +47,19 @@ def main(server: "UserServer"):
                             },
                             {
                                 "name": "GITLAB_OAUTH_TOKEN",
-                                "value": server._user.git_token,
+                                "value": str(server._user.git_token),
+                            },
+                            {
+                                "name": "GITLAB_OAUTH_TOKEN_EXPIRES_AT",
+                                "value": str(server._user.git_token_expires_at),
+                            },
+                            {
+                                "name": "RENKU_JWT",
+                                "value": str(server._user.access_token),
+                            },
+                            {
+                                "name": "RENKU_URL",
+                                "value": "https://" + config.sessions.ingress.host,
                             },
                             {
                                 "name": "ANONYMOUS_SESSION",

--- a/renku_notebooks/api/classes/user.py
+++ b/renku_notebooks/api/classes/user.py
@@ -125,7 +125,12 @@ class RegisteredUser(User):
         )
         git_token = token_match.group(1) if token_match is not None else None
         git_token_expires_at = git_credentials["AccessTokenExpiresAt"]
-        return git_url, git_credentials["AuthorizationHeader"], git_token, git_token_expires_at
+        return (
+            git_url,
+            git_credentials["AuthorizationHeader"],
+            git_token,
+            git_token_expires_at,
+        )
 
     def get_autosaves(self, namespace_project=None):
         """Get a list of autosaves for all projects for the user"""


### PR DESCRIPTION
This allows the git proxy sidecar to reach out to the gateway with a valid but potentially expired oauth access token from keycloak. The gateway will ensure the token has a valid matching signature using the keycloak public key. If the "exp" claim of the token is past the gateway ignores this and will refresh the keycloak token. Also after this the gateway will proceed to also refresh the gitlab access token as well.