### PR TITLE
fix(app): snyk vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,6 @@ tags
 .config.hocon
 
 # End of https://www.gitignore.io/api/vim,linux,emacs,macos,python,sublimetext,visualstudiocode
+
+# Ignore snyk cache
+.dccache


### PR DESCRIPTION
Clears cross site scripting vulnerabilities reported by snyk.

These were impossible to occur because they are related to the `server_name` parameter being used to query k8s for the specific server name and then return the server.

So if a malformed or malicious string was passed then the server would simply not be found in k8s.

Either way by using `jsonify` from `flask` if there are any malicious content in the parameter and if that somehow finds its way back into the the response then the content would be properly escaped.

I ran `SNYK_CFG_ORG=renku snyk code test` locally after making these changes to make sure they are properly addressed and they are.

/deploy #persist renku-gateway=master renku=master
