### PR TITLE
fix(sidecar): use list of args in git LFS commands

### DIFF
--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -126,7 +126,7 @@ class GitCloner:
     def _get_lfs_total_size_bytes(self) -> int:
         """Get the total size of all LFS files in bytes."""
         try:
-            res = self.cli.git_lfs("ls-files --json")
+            res = self.cli.git_lfs("ls-files", "--json")
         except GitCommandError:
             return 0
         res_json = json.loads(res)
@@ -160,7 +160,7 @@ class GitCloner:
             _, _, free_space_bytes = disk_usage(self.cli.repo_directory)
             if free_space_bytes < total_lfs_size_bytes:
                 raise errors.NoDiskSpaceError
-            self.cli.git_lfs("install --local")
+            self.cli.git_lfs("install", "--local")
             self.cli.git_lfs("pull")
         try:
             logging.info("Dealing with submodules")


### PR DESCRIPTION
I recently merged an old PR about checking the LFS size and disk size available before we pull the LFS data (#1226). 

#1226 added runs `git lfs` commands through the thin git wrapper we have. But after #1226 was opened but before it was merged we made the git wrapper accept only a list of arguments as parameters rather than all parameters as one string. When I merged #1226 there were 2-3 `git lfs commands` that were passing a single string with space separated parameters rather than a list.

This corrects that problem so that the git wrapper is used properly.