### PR TITLE
feat(session): fail when injecting env vars that exist in session

### DIFF
--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -367,7 +367,8 @@ class UserServer:
         }
         return manifest
 
-    def _check_environment_variables_overrides(self, patches_list):
+    @staticmethod
+    def _check_environment_variables_overrides(patches_list):
         """Check if any patch overrides server's environment variables with a different value,
         or if two patches create environment variables with different values."""
         env_vars = {}

--- a/renku_notebooks/api/notebooks.py
+++ b/renku_notebooks/api/notebooks.py
@@ -169,7 +169,7 @@ def launch_notebook(
     image,
     server_options,
     environment_variables,
-    cloudstorage=[],
+    cloudstorage=None,
 ):
     """
     Launch a Jupyter server.
@@ -217,7 +217,7 @@ def launch_notebook(
         image,
         server_options,
         environment_variables,
-        cloudstorage,
+        cloudstorage or [],
         config.k8s.client,
     )
 

--- a/renku_notebooks/errors/programming.py
+++ b/renku_notebooks/errors/programming.py
@@ -39,3 +39,11 @@ class FilteringResourcesError(ProgrammingError):
 
     message: str
     code: int = ProgrammingError.code + 2
+
+
+@dataclass
+class DuplicateEnvironmentVariableError(ProgrammingError):
+    """Raised when amalthea patches are overriding an env var with different values."""
+
+    message: str
+    code: int = ProgrammingError.code + 3

--- a/renku_notebooks/errors/user.py
+++ b/renku_notebooks/errors/user.py
@@ -68,3 +68,11 @@ class InvalidCloudStorageUrl(UserInputError):
 
     message: str = "The url for the cloud storage endpoint is not valid."
     code: int = UserInputError.code + 3
+
+
+@dataclass
+class OverriddenEnvironmentVariableError(UserInputError):
+    """Raised when an amalthea patch is overriding a session's env var with a different value."""
+
+    message: str
+    code: int = UserInputError.code + 4

--- a/tests/unit/test_server_class/test_manifest.py
+++ b/tests/unit/test_server_class/test_manifest.py
@@ -1,8 +1,29 @@
+from typing import Any, Dict
+
 import pytest
 
 from renku_notebooks.api.classes.k8s_client import K8sClient
 from renku_notebooks.api.classes.server import UserServer
+from renku_notebooks.errors.programming import DuplicateEnvironmentVariableError
 from renku_notebooks.errors.user import OverriddenEnvironmentVariableError
+
+BASE_PARAMETERS = {
+    "namespace": "test-namespace",
+    "project": "test-project",
+    "image": None,
+    "server_options": {
+        "lfs_auto_fetch": 0,
+        "defaultUrl": "/lab",
+        "cpu_request": "100",
+        "mem_request": "100",
+        "disk_request": "100",
+    },
+    "branch": "master",
+    "commit_sha": "abcdefg123456789",
+    "notebook": "",
+    "environment_variables": {},
+    "cloudstorage": [],
+}
 
 
 # TODO: Add more tests https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1145
@@ -24,29 +45,10 @@ def test_session_manifest(
     mocker,
 ):
     """Test that session manifest can be created correctly."""
-
-    user = user_with_project_path("namespace/project")
     with app.app_context():
-        mock_k8s_client = mocker.MagicMock(K8sClient)
-        base_parameters = {
-            "user": user,
-            "namespace": "test-namespace",
-            "project": "test-project",
-            "image": None,
-            "server_options": {
-                "lfs_auto_fetch": 0,
-                "defaultUrl": "/lab",
-                "cpu_request": "100",
-                "mem_request": "100",
-                "disk_request": "100",
-            },
-            "branch": "master",
-            "commit_sha": "abcdefg123456789",
-            "notebook": "",
-            "environment_variables": {},
-            "cloudstorage": [],
-            "k8s_client": mock_k8s_client,
-        }
+        base_parameters = BASE_PARAMETERS.copy()
+        base_parameters["user"] = user_with_project_path("namespace/project")
+        base_parameters["k8s_client"] = mocker.MagicMock(K8sClient)
 
         server = UserServer(**{**base_parameters, **parameters})
         server.image_workdir = ""
@@ -60,33 +62,53 @@ def test_session_env_var_override(
     patch_user_server, user_with_project_path, app, mocker
 ):
     """Test that when a patch overrides session env vars an error is raised."""
-
-    user = user_with_project_path("namespace/project")
     with app.app_context():
-        mock_k8s_client = mocker.MagicMock(K8sClient)
-        parameters = {
-            "user": user,
-            "namespace": "test-namespace",
-            "project": "test-project",
-            "image": None,
-            "server_options": {
-                "lfs_auto_fetch": 0,
-                "defaultUrl": "/lab",
-                "cpu_request": "100",
-                "mem_request": "100",
-                "disk_request": "100",
-            },
-            "branch": "master",
-            "commit_sha": "abcdefg123456789",
-            "notebook": "",
-            # NOTE: NOTEBOOK_DIR is defined in ``jupyter_server.env`` patch
-            "environment_variables": {"NOTEBOOK_DIR": "/some/path"},
-            "cloudstorage": [],
-            "k8s_client": mock_k8s_client,
-        }
+        parameters: Dict[str, Any] = BASE_PARAMETERS.copy()
+        parameters["user"] = user_with_project_path("namespace/project")
+        parameters["k8s_client"] = mocker.MagicMock(K8sClient)
+        # NOTE: NOTEBOOK_DIR is defined in ``jupyter_server.env`` patch
+        parameters["environment_variables"] = {"NOTEBOOK_DIR": "/some/path"}
 
         server = UserServer(**parameters)
         server.image_workdir = ""
 
-        with pytest.raises(OverriddenEnvironmentVariableError) as e:
+        with pytest.raises(OverriddenEnvironmentVariableError):
+            server._get_session_manifest()
+
+
+def test_patches_env_var_override(
+    patch_user_server, user_with_project_path, app, mocker
+):
+    """Test that when multiple patches define the same env vars with different values an error is
+    raised."""
+    general_patches = mocker.patch(
+        "renku_notebooks.api.classes.server.general_patches.oidc_unverified_email",
+        autospec=True,
+    )
+    # NOTE: Override ``jupyter_server.env::RENKU_USERNAME`` env var with a different value
+    general_patches.return_value = [
+        {
+            "type": "application/json-patch+json",
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/statefulset/spec/template/spec/containers/0/env/-",
+                    "value": {
+                        "name": "RENKU_USERNAME",
+                        "value": "some-different-value",
+                    },
+                },
+            ],
+        }
+    ]
+
+    with app.app_context():
+        parameters = BASE_PARAMETERS.copy()
+        parameters["user"] = user_with_project_path("namespace/project")
+        parameters["k8s_client"] = mocker.MagicMock(K8sClient)
+
+        server = UserServer(**parameters)
+        server.image_workdir = ""
+
+        with pytest.raises(DuplicateEnvironmentVariableError):
             server._get_session_manifest()

--- a/tests/unit/test_server_class/test_manifest.py
+++ b/tests/unit/test_server_class/test_manifest.py
@@ -2,6 +2,7 @@ import pytest
 
 from renku_notebooks.api.classes.k8s_client import K8sClient
 from renku_notebooks.api.classes.server import UserServer
+from renku_notebooks.errors.user import OverriddenEnvironmentVariableError
 
 
 # TODO: Add more tests https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1145
@@ -53,3 +54,39 @@ def test_session_manifest(
         manifest = server._get_session_manifest()
 
     assert expected in str(manifest)
+
+
+def test_session_env_var_override(
+    patch_user_server, user_with_project_path, app, mocker
+):
+    """Test that when a patch overrides session env vars an error is raised."""
+
+    user = user_with_project_path("namespace/project")
+    with app.app_context():
+        mock_k8s_client = mocker.MagicMock(K8sClient)
+        parameters = {
+            "user": user,
+            "namespace": "test-namespace",
+            "project": "test-project",
+            "image": None,
+            "server_options": {
+                "lfs_auto_fetch": 0,
+                "defaultUrl": "/lab",
+                "cpu_request": "100",
+                "mem_request": "100",
+                "disk_request": "100",
+            },
+            "branch": "master",
+            "commit_sha": "abcdefg123456789",
+            "notebook": "",
+            # NOTE: NOTEBOOK_DIR is defined in ``jupyter_server.env`` patch
+            "environment_variables": {"NOTEBOOK_DIR": "/some/path"},
+            "cloudstorage": [],
+            "k8s_client": mock_k8s_client,
+        }
+
+        server = UserServer(**parameters)
+        server.image_workdir = ""
+
+        with pytest.raises(OverriddenEnvironmentVariableError) as e:
+            server._get_session_manifest()


### PR DESCRIPTION
Checks that user doesn't override env vars sets by Amalthea patches and that Amalthea patches don't override the same env var with different values (in the same container).

Fixes: #1311 