### PR TITLE
fix(sidecar): anon users clone repo at correct SHA

### DIFF
--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -223,6 +223,7 @@ class GitCloner:
         self._initialize_repo()
         if self.user.is_anonymous:
             self._clone(session_branch)
+            self.cli.git_reset("--hard", root_commit_sha)
         else:
             with self._temp_plaintext_credentials():
                 self._clone(session_branch)


### PR DESCRIPTION
If an anonymous user requests a session at a commit sha other than head then they would always get head.

This happened only for anonymous sessions. This fixes the problem.

/deploy #persist