### PR TITLE
chore: use server instead of notebook

### DIFF
--- a/renku_notebooks/api/amalthea_patches/jupyter_server.py
+++ b/renku_notebooks/api/amalthea_patches/jupyter_server.py
@@ -96,7 +96,7 @@ def args():
                 {
                     "op": "add",
                     "path": "/statefulset/spec/template/spec/containers/0/args",
-                    "value": ["jupyter", "lab"],
+                    "value": ["jupyter", "server"],
                 }
             ],
         }

--- a/renku_notebooks/api/amalthea_patches/jupyter_server.py
+++ b/renku_notebooks/api/amalthea_patches/jupyter_server.py
@@ -96,7 +96,7 @@ def args():
                 {
                     "op": "add",
                     "path": "/statefulset/spec/template/spec/containers/0/args",
-                    "value": ["jupyter", "notebook"],
+                    "value": ["jupyter", "lab"],
                 }
             ],
         }


### PR DESCRIPTION
We can use the generic `jupyter server` to (hopefully) reliably set the various defaults. 

/deploy #persist