### PR TITLE
feat(app): prefer to launch with `jupyter server`

### DIFF
--- a/renku_notebooks/api/amalthea_patches/jupyter_server.py
+++ b/renku_notebooks/api/amalthea_patches/jupyter_server.py
@@ -95,9 +95,14 @@ def args():
             "patch": [
                 {
                     "op": "add",
+                    "path": "/statefulset/spec/template/spec/containers/0/command",
+                    "value": ["sh", "-c"],
+                },
+                {
+                    "op": "add",
                     "path": "/statefulset/spec/template/spec/containers/0/args",
-                    "value": ["jupyter", "notebook"],
-                }
+                    "value": ["jupyter server || jupyter notebook"],
+                },
             ],
         }
     )


### PR DESCRIPTION
As reported by @rokroskar 

> I’ve stumbled across an annoying issue whose resolution isn’t super obvious but has potentially annoying/far-reaching consequences… so would appreciate some feedback
> - we base our image off the jupyter stack; it’s convenient, most of the setup is done, they’re maintained by someone else
> - when we start the jupyter container for a user session, we run the command jupyter notebook - this actually starts the “legacy” notebook but in older versions of jupyter it didn’t matter, jupyter notebook and jupyter lab both got started at the same time for the same server, even though they are technically different applications
> - with new versions of jupyter, these are more strictly separated - running jupyter notebook  means that the /lab endpoint is not available and notebook  only runs the legacy notebook (e.g. available under  /tree )
> - it’s convenient to instead use jupyter server - this is also actually what we want because this only launches the server and doesn’t make assumptions about which extensions you might want to run, but it makes the “modern” extensions (like lab) available
> - so, in order to use current versions of jupyter, we need to use jupyter server - but older versions of jupyter don’t know about this command and fail.
> - if we inject jupyter server as the command we run in the containers, older projects will not be able to launch; if we don’t, we can’t keep up with jupyter upgrades.

Hopefully this helps. We should test.

/deploy #persist