### PR TITLE
chore(app): Update default session image to renku/renkulab-py:3.9-0.17.0

### DIFF
--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -238,7 +238,7 @@ serverDefaults:
 enforceCPULimits: "off"
 
 ## Default image used when the requested image for a user session cannot be found.
-defaultSessionImage: "renku/renkulab-py:3.9-0.16.0"
+defaultSessionImage: "renku/renkulab-py:3.9-0.17.0"
 
 gitRpcServer:
   image:


### PR DESCRIPTION
Generated automatically on a new release in renkulab-docker to update the default image used when launching a user session.