### PR TITLE
fix(app): properly recover LFS from autosave

### DIFF
--- a/git_services/git_services/cli/__init__.py
+++ b/git_services/git_services/cli/__init__.py
@@ -86,3 +86,6 @@ class GitCLI:
 
     def git_clone(self, *args):
         return self._execute_command("git", "clone", *args)
+
+    def git_diff(self, *args):
+        return self._execute_command("git", "diff", *args)


### PR DESCRIPTION
This is an issue that Till discovered that if there are LFS files in the autosave branch they do not get recovered. The reason for this is that by default we do not pull LFS files (even when recovering an autosave). So any files that were checked in LFS and created with the autosave are lost and only the LFS pointers (which are not valid anymore) are left. And the pointers point to the non-existent branch and LFS data.

This corrects the problem.

/deploy #persist