### PR TITLE
fix secret order and mount path check

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -23,6 +23,7 @@ jobs:
       renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
       renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
       renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
+      renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
@@ -62,6 +63,7 @@ jobs:
           renku_core: "${{ needs.check-deploy.outputs.renku-core }}"
           renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
           renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"
+          renku_data_services: "${{ needs.check-deploy.outputs.renku-data-services }}"
           renku_ui: "${{ needs.check-deploy.outputs.renku-ui }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
       - name: Check existing renkubot comment

--- a/renku_notebooks/api/amalthea_patches/cloudstorage.py
+++ b/renku_notebooks/api/amalthea_patches/cloudstorage.py
@@ -11,7 +11,7 @@ def main(server: "UserServer") -> List[Dict[str, Any]]:
     if not server.cloudstorage:
         return []
     for i, cloud_storage_request in enumerate(server.cloudstorage):
-        cloud_storage_patches.append(
+        cloud_storage_patches.extend(
             cloud_storage_request.get_manifest_patch(
                 f"{server.server_name}-ds-{i}", server.k8s_client.preferred_namespace
             )

--- a/renku_notebooks/api/classes/cloud_storage/__init__.py
+++ b/renku_notebooks/api/classes/cloud_storage/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod, abstractproperty
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 class ICloudStorageRequest(ABC):
@@ -26,5 +26,5 @@ class ICloudStorageRequest(ABC):
         namespace: str,
         labels: Dict[str, str] = {},
         annotations: Dict[str, str] = {},
-    ) -> Dict[str, Any]:
+    ) -> List[Dict[str, Any]]:
         pass

--- a/renku_notebooks/api/schemas/cloud_storage.py
+++ b/renku_notebooks/api/schemas/cloud_storage.py
@@ -37,7 +37,7 @@ def create_cloud_storage_object(data: Dict[str, Any], user: User, project_id: in
     if data.get("storage_id"):
         # Load from storage service
         if user.access_token is None:
-            raise ValidationError("Storage mounting only supported for logged-in users.")
+            raise ValidationError("Storage mounting is only supported for logged-in users.")
         if project_id < 1:
             raise ValidationError("Could not get gitlab project id")
         (
@@ -73,7 +73,7 @@ def create_cloud_storage_object(data: Dict[str, Any], user: User, project_id: in
             endpoint=configuration["endpoint"],
             container=bucket,
             credential=configuration["secret_access_key"],
-            mount_folder=work_dir / target_path,
+            mount_folder=str(work_dir / target_path),
             source_folder=source_path,
             read_only=readonly,
         )


### PR DESCRIPTION
- reorders patches to create secrets before creating dataset CRD
- fixes `target_path` to instead ufse `mount_folder` property (the formet didn't exist)
- Wraps marshmallow ValidationErrors in UserInputError

/deploy renku=data-service-chart renku-gateway=master renku-notebooks=master renku-data-services=main renku-ui=master extra-values=dataService.image.pullPolicy=Always,global.gitlab.url=gitlab.dev.renku.ch,notebooks.cloudstorage.s3.enabled=true,amalthea.extraChildResources[0].group=com.ie.ibm.hpsys,amalthea.extraChildResources[0].name=datasets,notebooks.cloudstorage.s3.installDatashim=false