### PR TITLE
chore: prep 1.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for renku-notebooks
 
+## [1.20.1](https://github.com/SwissDataScienceCenter/renku-notebooks/compare/1.20.0...1.20.1) (2023-11-06)
+
+
+### Bug Fixes
+
+* properly patch tolerations and affinities ([#1695](https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1695)) ([a45cee3](https://github.com/SwissDataScienceCenter/renku-notebooks/commit/a45cee3523453273cfa7281058c044a02516be74))
+
+
+
+
 ## [1.20.0](https://github.com/SwissDataScienceCenter/renku-notebooks/compare/1.19.1...1.20.0) (2023-10-23)
 
 ### Bug Fixes

--- a/helm-chart/renku-notebooks/Chart.yaml
+++ b/helm-chart/renku-notebooks/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for the Renku Notebooks service
 name: renku-notebooks
-version: 1.20.0
+version: 1.20.1

--- a/helm-chart/renku-notebooks/values.yaml
+++ b/helm-chart/renku-notebooks/values.yaml
@@ -1,34 +1,34 @@
 notebooks:
   image:
     repository: renku/renku-notebooks
-    tag: "1.20.0"
+    tag: "1.20.1"
 
   gitRpcServer:
     image:
       name: renku/git-rpc-server
-      tag: "1.20.0"
+      tag: "1.20.1"
 
   gitHttpsProxy:
     image:
       name: renku/git-https-proxy
-      tag: "1.20.0"
+      tag: "1.20.1"
 
   gitClone:
     image:
       name: renku/git-clone
-      tag: "1.20.0"
+      tag: "1.20.1"
 
   tests:
     image:
       repository: renku/renku-notebooks-tests
-      tag: "1.20.0"
+      tag: "1.20.1"
 
   k8sWatcher:
     image:
       repository: renku/k8s-watcher
-      tag: "1.20.0"
+      tag: "1.20.1"
 
   ssh:
     image:
       repository: renku/ssh-jump-host
-      tag: "1.20.0"
+      tag: "1.20.1"


### PR DESCRIPTION
A new bugfix release to allow proper templating of tolerations and affinities that are stored in the CRC.