### PR TITLE
fix: clone the correct commit

### DIFF
--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -182,10 +182,10 @@ class GitCloner:
         self._initialize_repo()
         if self.user.is_anonymous:
             self._clone(session_branch)
-            self.cli.git_reset("--hard", root_commit_sha)
         else:
             with self._temp_plaintext_credentials():
                 self._clone(session_branch)
+        self.cli.git_reset("--hard", root_commit_sha)
         # NOTE: If the S3 mount location already exists it means that the repo folder/file
         # or another existing file will be overwritten, so raise an error here and crash.
         for a_mount in s3_mounts:

--- a/git_services/tests/test_init_clone.py
+++ b/git_services/tests/test_init_clone.py
@@ -33,8 +33,12 @@ def test_simple_git_clone(test_user, clone_dir, mocker):
     mocker.patch("git_services.init.cloner.GitCloner._temp_plaintext_credentials", autospec=True)
     cloner = GitCloner(git_url=git_url, repo_url=repo_url, repo_directory=clone_dir, user=test_user)
     assert len(os.listdir(clone_dir)) == 0
-    cloner.run(session_branch="main", root_commit_sha="test", s3_mounts=[])
+    cloner.run(session_branch="main", root_commit_sha="HEAD~4", s3_mounts=[])
     assert len(os.listdir(clone_dir)) != 0
+    git_cli = GitCLI(clone_dir)
+    assert git_cli._execute_command(
+        "git", "rev-parse", "origin/main~4"
+    ) == git_cli._execute_command("git", "rev-parse", "HEAD")
 
 
 def test_lfs_size_check(test_user, clone_dir, mocker):


### PR DESCRIPTION
When we removed the autosave stuff we ended up removing the part that checks out the correct commit.  Because the commit was changed/adjusted only if there were no autosaves or unsaved work.

But now we check if the repo is present and then we leave it alone. But if the repo is not present we clone and then do not adjust the commit for registered users.

With this change we will have the right commit.

/deploy