### PR TITLE
fix: patch in a larger value for /dev/shm

### DIFF
--- a/renku_notebooks/api/amalthea_patches/general.py
+++ b/renku_notebooks/api/amalthea_patches/general.py
@@ -189,3 +189,36 @@ def oidc_unverified_email(server: "UserServer"):
             }
         )
     return patches
+
+
+def dev_shm(server: "UserServer"):
+    patches = []
+    if server.server_options.storage:
+        patches.append(
+            {
+                "type": "application/json-patch+json",
+                "patch": [
+                    {
+                        "op": "add",
+                        "path": "/statefulset/spec/template/spec/volumes/-",
+                        "value": {
+                            "name": "shm",
+                            "emptyDir": {
+                                "medium": "Memory",
+                                # NOTE: We are giving /dev/shm up to half of the memory request
+                                "sizeLimit": int(server.server_options.storage / 2),
+                            },
+                        },
+                    },
+                    {
+                        "op": "add",
+                        "path": "/statefulset/spec/template/spec/containers/1/volumeMounts/-",
+                        "value": {
+                            "mountPath": "/dev/shm",
+                            "name": "shm",
+                        },
+                    },
+                ],
+            }
+        )
+    return patches

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -179,6 +179,7 @@ class UserServer:
                 general_patches.session_affinity(self),
                 general_patches.session_node_selector(self),
                 general_patches.priority_class(self),
+                general_patches.dev_shm(self),
                 jupyter_server_patches.args(),
                 jupyter_server_patches.env(self),
                 jupyter_server_patches.image_pull_secret(self),


### PR DESCRIPTION
This adds a larger value for shared memory in the jupyter session.

This is needed when multiple gpus are used for training or simply when a lot of data is being loaded into the gpus for large models.

We have had complaints that training jobs and models are failing because this value is too low.

We have semi-arbitrarily decided to set a limit of half the memory requested for this.

/deploy
