### PR TITLE
fix: make dataconf ignore unexpected env vars

### DIFF
--- a/renku_notebooks/config/__init__.py
+++ b/renku_notebooks/config/__init__.py
@@ -142,7 +142,9 @@ def get_config(default_config: str) -> _NotebooksConfig:
     config = dataconf.multi.string(default_config)
     if config_file:
         config = config.file(config_file)
-    notebooks_config: _NotebooksConfig = config.env("NB_").on(_NotebooksConfig)
+    notebooks_config: _NotebooksConfig = config.env("NB_", ignore_unexpected=True).on(
+        _NotebooksConfig
+    )
     return notebooks_config
 
 


### PR DESCRIPTION
/deploy renku=add-missing-default-value renku-data-services=v0.9.0