### PR TITLE
fix: do not add storage mounts patches when a session has no repository

### DIFF
--- a/renku_notebooks/api/amalthea_patches/cloudstorage.py
+++ b/renku_notebooks/api/amalthea_patches/cloudstorage.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 def main(server: "UserServer") -> list[dict[str, Any]]:
     cloud_storage_patches: list[dict[str, Any]] = []
     cloud_storage_request: "ICloudStorageRequest"
-    if not server.cloudstorage or not server.repositories:
+    if not server.cloudstorage:
         return []
     for i, cloud_storage_request in enumerate(server.cloudstorage):
         cloud_storage_patches.extend(
@@ -16,19 +16,20 @@ def main(server: "UserServer") -> list[dict[str, Any]]:
                 f"{server.server_name}-ds-{i}", server.k8s_client.preferred_namespace
             )
         )
-        cloud_storage_patches.append(
-            {
-                "type": "application/json-patch+json",
-                "patch": [
-                    {
-                        "op": "add",
-                        "path": "/statefulset/spec/template/spec/initContainers/2/env/-",
-                        "value": {
-                            "name": f"GIT_CLONE_STORAGE_MOUNTS_{i}",
-                            "value": cloud_storage_request.mount_folder,
+        if server.repositories:
+            cloud_storage_patches.append(
+                {
+                    "type": "application/json-patch+json",
+                    "patch": [
+                        {
+                            "op": "add",
+                            "path": "/statefulset/spec/template/spec/initContainers/2/env/-",
+                            "value": {
+                                "name": f"GIT_CLONE_STORAGE_MOUNTS_{i}",
+                                "value": cloud_storage_request.mount_folder,
+                            },
                         },
-                    },
-                ],
-            },
-        )
+                    ],
+                },
+            )
     return cloud_storage_patches

--- a/renku_notebooks/api/amalthea_patches/cloudstorage.py
+++ b/renku_notebooks/api/amalthea_patches/cloudstorage.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 def main(server: "UserServer") -> list[dict[str, Any]]:
     cloud_storage_patches: list[dict[str, Any]] = []
     cloud_storage_request: "ICloudStorageRequest"
-    if not server.cloudstorage:
+    if not server.cloudstorage or not server.repositories:
         return []
     for i, cloud_storage_request in enumerate(server.cloudstorage):
         cloud_storage_patches.extend(

--- a/renku_notebooks/api/amalthea_patches/git_proxy.py
+++ b/renku_notebooks/api/amalthea_patches/git_proxy.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
 
 
 def main(server: "UserServer"):
+    if server.user.anonymous or not server.repositories:
+        return []
+
     etc_cert_volume_mount = get_certificates_volume_mounts(
         custom_certs=False,
         etc_certs=True,

--- a/renku_notebooks/api/amalthea_patches/git_sidecar.py
+++ b/renku_notebooks/api/amalthea_patches/git_sidecar.py
@@ -12,6 +12,8 @@ def main(server: "UserServer"):
     # NOTE: Sessions can be persisted only for registered users
     if not isinstance(server.user, RegisteredUser):
         return []
+    if not server.repositories:
+        return []
 
     gitlab_project = getattr(server, "gitlab_project", None)
     gl_project_path = gitlab_project.path if gitlab_project else None

--- a/renku_notebooks/api/amalthea_patches/init_containers.py
+++ b/renku_notebooks/api/amalthea_patches/init_containers.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
 
 
 def git_clone(server: "UserServer"):
+    if not server.repositories:
+        return []
+
     etc_cert_volume_mount = get_certificates_volume_mounts(
         custom_certs=False,
         etc_certs=True,

--- a/renku_notebooks/api/classes/server.py
+++ b/renku_notebooks/api/classes/server.py
@@ -292,8 +292,6 @@ class UserServer(ABC):
         return config.session_get_endpoint_annotations.renku_annotation_prefix
 
     def _get_patches(self) -> list[dict[str, Any]]:
-        has_repository = bool(self.repositories)
-
         return list(
             chain(
                 general_patches.test(self),
@@ -308,19 +306,15 @@ class UserServer(ABC):
                 jupyter_server_patches.disable_service_links(),
                 jupyter_server_patches.rstudio_env_variables(self),
                 jupyter_server_patches.user_secrets(self),
-                (
-                    git_proxy_patches.main(self)
-                    if has_repository and not self.user.anonymous
-                    else []
-                ),
-                git_sidecar_patches.main(self) if has_repository else [],
+                git_proxy_patches.main(self),
+                git_sidecar_patches.main(self),
                 general_patches.oidc_unverified_email(self),
                 ssh_patches.main(),
                 # init container for certs must come before all other init containers
                 # so that it runs first before all other init containers
                 init_containers_patches.certificates(),
                 init_containers_patches.download_image(self),
-                init_containers_patches.git_clone(self) if has_repository else [],
+                init_containers_patches.git_clone(self),
                 inject_certificates_patches.proxy(self),
                 # Cloud Storage needs to patch the git clone sidecar spec and so should come after
                 # the sidecars


### PR DESCRIPTION
Fixes #1891.

Also moves conditions for empty patches inside their respective functions.

/deploy renku=master