### PR TITLE
fix: Mount /dev/shm to the correct container.

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -29,7 +29,7 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.3
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.12.3
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -43,7 +43,7 @@ jobs:
       url: https://renku-ci-nb-${{ github.event.number }}.dev.renku.ch
     steps:
       - name: deploy-pr
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.3
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.12.3
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -89,7 +89,7 @@ jobs:
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.11.3
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.12.3
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku-ci-nb-${{ github.event.number }}
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.11.3
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.12.3
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -132,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.11.3
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.12.3
         env:
           HELM_RELEASE_REGEX: "^renku-ci-nb-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/renku_notebooks/api/amalthea_patches/general.py
+++ b/renku_notebooks/api/amalthea_patches/general.py
@@ -201,32 +201,33 @@ def oidc_unverified_email(server: "UserServer"):
 
 def dev_shm(server: "UserServer"):
     patches = []
-    if server.server_options.storage:
-        patches.append(
-            {
-                "type": "application/json-patch+json",
-                "patch": [
-                    {
-                        "op": "add",
-                        "path": "/statefulset/spec/template/spec/volumes/-",
-                        "value": {
-                            "name": "shm",
-                            "emptyDir": {
-                                "medium": "Memory",
-                                # NOTE: We are giving /dev/shm up to half of the memory request
-                                "sizeLimit": int(server.server_options.storage / 2),
-                            },
+    patches.append(
+        {
+            "type": "application/json-patch+json",
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/statefulset/spec/template/spec/volumes/-",
+                    "value": {
+                        "name": "shm",
+                        "emptyDir": {
+                            "medium": "Memory",
+                            # NOTE: We are giving /dev/shm up to half of the memory request
+                            "sizeLimit": int(server.server_options.memory / 2)
+                            if isinstance(server.server_options.memory, int)
+                            else "1Gi",
                         },
                     },
-                    {
-                        "op": "add",
-                        "path": "/statefulset/spec/template/spec/containers/1/volumeMounts/-",
-                        "value": {
-                            "mountPath": "/dev/shm",
-                            "name": "shm",
-                        },
+                },
+                {
+                    "op": "add",
+                    "path": "/statefulset/spec/template/spec/containers/0/volumeMounts/-",
+                    "value": {
+                        "mountPath": "/dev/shm",
+                        "name": "shm",
                     },
-                ],
-            }
-        )
+                },
+            ],
+        }
+    )
     return patches


### PR DESCRIPTION
Currently container #1 is `oauth-proxy` while JupyterServer, is #0.

Additionally use half of the memory requested by the pod instead of half of the storage.

Since we rely on memory there is no need to tie the increased /dev/shm to requesting storage in the session.

NOTE: This system of patching the manifest is very brittle and the bug being fixed by this commit might appear again as soon as the containers sorting changes. We should think about a different way of interacting with the manifests of the user-sessions.

/deploy renku=leafty/fix-renku-jupyterserver