### PR TITLE
fix: image checks for some oci images failed

### DIFF
--- a/renku_notebooks/api/classes/image.py
+++ b/renku_notebooks/api/classes/image.py
@@ -13,7 +13,8 @@ from ...errors.user import ImageParseError
 
 class ManifestTypes(Enum):
     docker_v2: str = "application/vnd.docker.distribution.manifest.v2+json"
-    oci_v1: str = "application/vnd.oci.image.manifest.v1+json"
+    oci_v1_manifest: str = "application/vnd.oci.image.manifest.v1+json"
+    oci_v1_index: str = "application/vnd.oci.image.index.v1+json"
 
 
 @dataclass
@@ -62,7 +63,10 @@ class ImageRepoDockerAPI:
             headers["Authorization"] = f"Bearer {token}"
         res = requests.get(image_digest_url, headers=headers)
         if res.status_code != 200:
-            headers["Accept"] = ManifestTypes.oci_v1.value
+            headers["Accept"] = ManifestTypes.oci_v1_manifest.value
+            res = requests.get(image_digest_url, headers=headers)
+        if res.status_code != 200:
+            headers["Accept"] = ManifestTypes.oci_v1_index.value
             res = requests.get(image_digest_url, headers=headers)
         if res.status_code != 200:
             return None

--- a/tests/unit/test_public_image_checks.py
+++ b/tests/unit/test_public_image_checks.py
@@ -183,6 +183,7 @@ def test_public_image_name_parsing(name, expected):
         ("renku/singleuser", True),
         ("madeuprepo/madeupproject:tag", False),
         ("olevski90/oci-image:0.0.1", True),
+        ("ghcr.io/linuxserver/nginx:latest", True)
     ],
 )
 @pytest.mark.integration


### PR DESCRIPTION
This occurs because some images (most likely when they support multiple architectures) have an index instead of just a manifest. An OCI index refers to a set of images. But when we were checking for images we were only checking for the manifest and did not have the option to support an index content type.

/deploy