### PR TITLE
feat: use different user labels in k8s watcher

### DIFF
--- a/k8s-watcher/cache.go
+++ b/k8s-watcher/cache.go
@@ -143,7 +143,7 @@ func NewJupyterServerCacheFromConfig(ctx context.Context, config Config, namespa
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(k8sDynamicClient, time.Minute, namespace, nil)
 	informer := factory.ForResource(resource).Informer()
 	lister := factory.ForResource(resource).Lister()
-	res = &Cache{informer: informer, lister: lister, namespace: namespace, userIDLabel: config.UserIDLabel}
+	res = &Cache{informer: informer, lister: lister, namespace: namespace, userIDLabel: config.JupyterServerUserIDLabel}
 	return
 }
 
@@ -157,7 +157,7 @@ func NewAmaltheaSessionCacheFromConfig(ctx context.Context, config Config, names
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(k8sDynamicClient, time.Minute, namespace, nil)
 	informer := factory.ForResource(resource).Informer()
 	lister := factory.ForResource(resource).Lister()
-	res = &Cache{informer: informer, lister: lister, namespace: namespace, userIDLabel: config.UserIDLabel}
+	res = &Cache{informer: informer, lister: lister, namespace: namespace, userIDLabel: config.AmaltheaSessionUserIDLabel}
 	return
 }
 

--- a/k8s-watcher/config.go
+++ b/k8s-watcher/config.go
@@ -43,10 +43,11 @@ type Config struct {
 	// The lable on the resources that identifies a specific user. This is used in the
 	// endpoints where the cache server will list resources that belong to a specific user.
 	// This is determined solely by a label selector on the specific label name specified
-	// in the two parameters below. The value that this key should match is passed as a path parameter in
+	// in the parameters below. The value that this key should match is passed as a path parameter in
 	// the http requests.
 	AmaltheaSessionUserIDLabel string
 	JupyterServerUserIDLabel   string
+	UserIDLabel                string
 	// The maximum duration to wait for all caches to sync.
 	CacheSyncTimeout time.Duration
 }
@@ -162,6 +163,12 @@ func NewConfigFromEnvOrDie(prefix string) Config {
 		config.AmaltheaSessionUserIDLabel = userIDLabel
 	} else {
 		config.AmaltheaSessionUserIDLabel = "renku.io/safe-username"
+	}
+
+	if userIDLabel, ok := os.LookupEnv(fmt.Sprintf("%sUSER_ID_LABEL", prefix)); ok {
+		config.UserIDLabel = userIDLabel
+	} else {
+		config.UserIDLabel = "renku.io/safe-username"
 	}
 
 	if cacheSyncTimeoutSeconds, ok := os.LookupEnv(fmt.Sprintf("%sCACHE_SYNC_TIMEOUT_SECONDS", prefix)); ok {

--- a/k8s-watcher/config.go
+++ b/k8s-watcher/config.go
@@ -43,9 +43,10 @@ type Config struct {
 	// The lable on the resources that identifies a specific user. This is used in the
 	// endpoints where the cache server will list resources that belong to a specific user.
 	// This is determined solely by a label selector on the specific label name specified
-	// by UserIDLabel. The value that this key should match is passed as a path parameter in
+	// in the two parameters below. The value that this key should match is passed as a path parameter in
 	// the http requests.
-	UserIDLabel string
+	AmaltheaSessionUserIDLabel string
+	JupyterServerUserIDLabel   string
 	// The maximum duration to wait for all caches to sync.
 	CacheSyncTimeout time.Duration
 }
@@ -151,10 +152,16 @@ func NewConfigFromEnvOrDie(prefix string) Config {
 		log.Fatalf("Invalid configuration, %sPORT must be provided\n", prefix)
 	}
 
-	if userIDLabel, ok := os.LookupEnv(fmt.Sprintf("%sUSER_ID_LABEL", prefix)); ok {
-		config.UserIDLabel = userIDLabel
+	if userIDLabel, ok := os.LookupEnv(fmt.Sprintf("%sJUPYTER_SERVER_USER_ID_LABEL", prefix)); ok {
+		config.JupyterServerUserIDLabel = userIDLabel
 	} else {
-		log.Fatalf("Invalid configuration, %sUSER_ID_LABEL must be provided\n", prefix)
+		config.JupyterServerUserIDLabel = "renku.io/userId"
+	}
+
+	if userIDLabel, ok := os.LookupEnv(fmt.Sprintf("%sAMALTHEA_SESSION_USER_ID_LABEL", prefix)); ok {
+		config.AmaltheaSessionUserIDLabel = userIDLabel
+	} else {
+		config.AmaltheaSessionUserIDLabel = "renku.io/safe-username"
 	}
 
 	if cacheSyncTimeoutSeconds, ok := os.LookupEnv(fmt.Sprintf("%sCACHE_SYNC_TIMEOUT_SECONDS", prefix)); ok {


### PR DESCRIPTION
This is necessary because the new and old servers have different labels that indicate the user ID that the session belongs to. So to stay compatible with older sessions and to enable the switch to the data service for v1 sessions this change is required.
