### PR TITLE
fix: handle empty git repository and handle ending slash

### DIFF
--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -273,6 +273,8 @@ class GitCloner:
 
                 traceback.print_exception(err, file=f)
             return
+        except errors.BranchDoesNotExistError as err:
+            logging.error(msg=f"Error while cloning {repository.url}", exc_info=err)
 
         # NOTE: If the storage mount location already exists it means that the repo folder/file
         # or another existing file will be overwritten, so raise an error here and crash.

--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -65,7 +65,8 @@ class Repository:
 
     @staticmethod
     def _make_dirname(url: str) -> str:
-        path = urlparse(url).path
+        parsed = urlparse(url)
+        path = parsed.path or parsed.hostname or ""
         path = path.removesuffix(".git").removesuffix("/")
         dirname = path.rsplit("/", maxsplit=1).pop()
         if dirname:

--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -32,7 +32,6 @@ class Repository:
     @classmethod
     def from_config_repo(cls, data: ConfigRepo, mount_path: Path):
         dirname = data.dirname or cls._make_dirname(data.url)
-        print(f"dirname = '{dirname}'")
         provider = data.provider
         branch = data.branch
         commit_sha = data.commit_sha

--- a/git_services/git_services/init/cloner.py
+++ b/git_services/git_services/init/cloner.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import random
 import re
+import string
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -30,6 +32,7 @@ class Repository:
     @classmethod
     def from_config_repo(cls, data: ConfigRepo, mount_path: Path):
         dirname = data.dirname or cls._make_dirname(data.url)
+        print(f"dirname = '{dirname}'")
         provider = data.provider
         branch = data.branch
         commit_sha = data.commit_sha
@@ -63,8 +66,12 @@ class Repository:
     @staticmethod
     def _make_dirname(url: str) -> str:
         path = urlparse(url).path
-        path = path.removesuffix(".git")
-        return path.rsplit("/", maxsplit=1).pop()
+        path = path.removesuffix(".git").removesuffix("/")
+        dirname = path.rsplit("/", maxsplit=1).pop()
+        if dirname:
+            return dirname
+        suffix = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(3)])  # nosec B311
+        return f"repo-{suffix}"
 
 
 @dataclass

--- a/git_services/git_services/sidecar/errors.py
+++ b/git_services/git_services/sidecar/errors.py
@@ -32,18 +32,14 @@ class SidecarProgrammingError(SidecarGenericError):
 class JSONRPCGenericError(JSONRPCDispatchException):
     """Base class for all JSON RPC errors."""
 
-    def __init__(
-        self, code=-32603, message="Something went wrong", data=None, *args, **kwargs
-    ):
+    def __init__(self, code=-32603, message="Something went wrong", data=None, *args, **kwargs):
         super().__init__(code, message, data, *args, **kwargs)
 
 
 class JSONRPCProgrammingError(JSONRPCDispatchException):
     """An error that cannot be corrected by the user the RPC server."""
 
-    def __init__(
-        self, code=-32000, message="Something went wrong", data=None, *args, **kwargs
-    ):
+    def __init__(self, code=-32000, message="Something went wrong", data=None, *args, **kwargs):
         super().__init__(code, message, data, *args, **kwargs)
 
 
@@ -90,9 +86,7 @@ def json_rpc_errors(func):
         except Exception as e:
             logging.exception(e)
             raise JSONRPCGenericError(
-                message=getattr(
-                    e, "message", f"Failed with an unexpected error of type {type(e)}"
-                )
+                message=getattr(e, "message", f"Failed with an unexpected error of type {type(e)}")
             )
 
     return _json_rpc_errors

--- a/git_services/tests/test_init_clone.py
+++ b/git_services/tests/test_init_clone.py
@@ -152,3 +152,22 @@ def test_git_clone_empty_url(test_user: User, clone_dir: str, mocker):
     cloner.run(storage_mounts=[])
 
     assert len(os.listdir(clone_dir)) != 0
+
+
+def test_git_clone_empty_repo(test_user: User, clone_dir: str, mocker):
+    repo_url = "https://gitlab.dev.renku.ch/flora.thiebaut/empty-project.git"
+    mocker.patch("git_services.init.cloner.GitCloner._temp_plaintext_credentials", autospec=True)
+    mount_path = Path(clone_dir)
+    repositories = [Repository.from_config_repo(ConfigRepo(url=repo_url), mount_path=mount_path)]
+    cloner = GitCloner(
+        repositories=repositories,
+        git_providers={},
+        mount_path=mount_path,
+        user=test_user,
+    )
+
+    assert len(os.listdir(clone_dir)) == 0
+
+    cloner.run(storage_mounts=[])
+
+    assert len(os.listdir(clone_dir)) != 0

--- a/git_services/tests/test_init_clone.py
+++ b/git_services/tests/test_init_clone.py
@@ -92,3 +92,63 @@ def test_lfs_output_parse(test_user, clone_dir, mocker, lfs_lfs_files_output, ex
     mocker.patch("git_services.init.cloner.Repository.git_cli", mock_cli)
 
     assert cloner._get_lfs_total_size_bytes(repository=repository) == expected_output
+
+
+def test_git_clone_unauthorized(test_user: User, clone_dir: str, mocker):
+    repo_url = "https://github.com/SwissDataScienceCenter/repository-does-not-exist.git"
+    mocker.patch("git_services.init.cloner.GitCloner._temp_plaintext_credentials", autospec=True)
+    mount_path = Path(clone_dir)
+    repositories = [Repository.from_config_repo(ConfigRepo(url=repo_url), mount_path=mount_path)]
+    cloner = GitCloner(
+        repositories=repositories,
+        git_providers={},
+        mount_path=mount_path,
+        user=test_user,
+    )
+
+    assert len(os.listdir(clone_dir)) == 0
+
+    cloner.run(storage_mounts=[])
+
+    assert len(os.listdir(clone_dir)) != 0
+
+    with open(Path(clone_dir).joinpath("repository-does-not-exist", "ERROR")) as f:
+        assert f.read() is not None
+
+
+def test_git_clone_not_a_git_url(test_user: User, clone_dir: str, mocker):
+    repo_url = "https://gitlab.renkulab.io/astronomy/introduction-to-astroparticle-physics/"
+    mocker.patch("git_services.init.cloner.GitCloner._temp_plaintext_credentials", autospec=True)
+    mount_path = Path(clone_dir)
+    repositories = [Repository.from_config_repo(ConfigRepo(url=repo_url), mount_path=mount_path)]
+    cloner = GitCloner(
+        repositories=repositories,
+        git_providers={},
+        mount_path=mount_path,
+        user=test_user,
+    )
+
+    assert len(os.listdir(clone_dir)) == 0
+
+    cloner.run(storage_mounts=[])
+
+    assert len(os.listdir(clone_dir)) != 0
+
+
+def test_git_clone_empty_url(test_user: User, clone_dir: str, mocker):
+    repo_url = ""
+    mocker.patch("git_services.init.cloner.GitCloner._temp_plaintext_credentials", autospec=True)
+    mount_path = Path(clone_dir)
+    repositories = [Repository.from_config_repo(ConfigRepo(url=repo_url), mount_path=mount_path)]
+    cloner = GitCloner(
+        repositories=repositories,
+        git_providers={},
+        mount_path=mount_path,
+        user=test_user,
+    )
+
+    assert len(os.listdir(clone_dir)) == 0
+
+    cloner.run(storage_mounts=[])
+
+    assert len(os.listdir(clone_dir)) != 0

--- a/git_services/tests/test_rpc_server.py
+++ b/git_services/tests/test_rpc_server.py
@@ -129,9 +129,7 @@ def test_error_endpoint(test_client, rpc_config: Config):
 
 
 @pytest.mark.parametrize("committed_changes", [True, False])
-def test_discard_unsaved_changes(
-    test_client, rpc_config: Config, clone_git_repo, committed_changes
-):
+def test_discard_unsaved_changes(test_client, rpc_config: Config, clone_git_repo, committed_changes):
     url = "https://github.com/SwissDataScienceCenter/renku.git"
     git_cli: GitCLI = clone_git_repo(url)
     with open(git_cli.repo_directory / "test.txt", "w") as f:


### PR DESCRIPTION
Closes #2006, closes #2011.

Allows the `git-clone` step to proceed when a git repository is empty and fix guessing the folder name.

/deploy #notest renku=release-0.65.0 renku-data-services=leafty/fix-cloudstorage-in-workdir