### PR TITLE
fix: backport SwissDataScienceCenter/renku-data-services#701

### DIFF
--- a/renku_notebooks/api/amalthea_patches/init_containers.py
+++ b/renku_notebooks/api/amalthea_patches/init_containers.py
@@ -26,10 +26,6 @@ def git_clone(server: "UserServer"):
     prefix = "GIT_CLONE_"
     env = [
         {
-            "name": f"{prefix}WORKSPACE_MOUNT_PATH",
-            "value": server.workspace_mount_path.absolute().as_posix(),
-        },
-        {
             "name": f"{prefix}MOUNT_PATH",
             "value": server.work_dir.absolute().as_posix(),
         },

--- a/renku_notebooks/api/amalthea_patches/init_containers.py
+++ b/renku_notebooks/api/amalthea_patches/init_containers.py
@@ -27,7 +27,7 @@ def git_clone(server: "UserServer"):
     env = [
         {
             "name": f"{prefix}MOUNT_PATH",
-            "value": server.work_dir.absolute().as_posix(),
+            "value": server.workspace_mount_path.absolute().as_posix(),
         },
         {
             "name": f"{prefix}LFS_AUTO_FETCH",


### PR DESCRIPTION
backport https://github.com/SwissDataScienceCenter/renku-data-services/pull/701

Tested here: https://renku-ci-nb-2013.dev.renku.ch/projects/flora.thiebaut/a-new-playground-project/sessions/new
Also tested in the `renku` repository: https://github.com/SwissDataScienceCenter/renku/actions/runs/13702131618/job/38320139809

/deploy renku=build/session-env-builders