### PR TITLE
fix: toggle on/off watching resources for image builds (#2014)

### DIFF
--- a/k8s-watcher/config.go
+++ b/k8s-watcher/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -25,6 +26,8 @@ type Config struct {
 	AmaltheaSessionVersion string
 	// The plural name of the AmaltheaSession resource that should be cached.
 	AmaltheaSessionPlural string
+	// Whether image building is enabled. If true, then Shipwright BuildRuns and Tekton TaskRuns are cached.
+	ImageBuildersEnabled bool
 	// The group of the ShipwrightBuildRun resource that should be cached.
 	ShipwrightBuildRunGroup string
 	// The version of the ShipwrightBuildRun resource that should be cached.
@@ -102,6 +105,12 @@ func NewConfigFromEnvOrDie(prefix string) Config {
 		config.AmaltheaSessionPlural = asPlural
 	} else {
 		config.AmaltheaSessionPlural = "amaltheasessions"
+	}
+
+	if ibEnabled, ok := os.LookupEnv(fmt.Sprintf("%sIMAGE_BUILDERS_ENABLED", prefix)); ok {
+		config.ImageBuildersEnabled = strings.ToLower(strings.Trim(ibEnabled, " ")) == "true"
+	} else {
+		config.ImageBuildersEnabled = false
 	}
 
 	if brGroup, ok := os.LookupEnv(fmt.Sprintf("%sSHIPWRIGHT_BUILDRUN_GROUP", prefix)); ok {

--- a/k8s-watcher/server.go
+++ b/k8s-watcher/server.go
@@ -15,8 +15,8 @@ import (
 type Server struct {
 	cachesJS CacheCollection
 	cachesAS CacheCollection
-	cachesBR CacheCollection
-	cachesTR CacheCollection
+	cachesBR *CacheCollection
+	cachesTR *CacheCollection
 	config   Config
 	router   *httprouter.Router
 	*http.Server
@@ -51,12 +51,21 @@ func (s *Server) Initialize(ctx context.Context) {
 	s.Handler = s
 	go s.cachesJS.run(ctx)
 	go s.cachesAS.run(ctx)
-	go s.cachesBR.run(ctx)
-	go s.cachesTR.run(ctx)
+	if s.cachesBR != nil {
+		go s.cachesBR.run(ctx)
+	}
+	if s.cachesTR != nil {
+		go s.cachesTR.run(ctx)
+	}
+
 	s.cachesJS.synchronize(ctx, s.config.CacheSyncTimeout)
 	s.cachesAS.synchronize(ctx, s.config.CacheSyncTimeout)
-	s.cachesBR.synchronize(ctx, s.config.CacheSyncTimeout)
-	s.cachesTR.synchronize(ctx, s.config.CacheSyncTimeout)
+	if s.cachesBR != nil {
+		s.cachesBR.synchronize(ctx, s.config.CacheSyncTimeout)
+	}
+	if s.cachesTR != nil {
+		s.cachesTR.synchronize(ctx, s.config.CacheSyncTimeout)
+	}
 }
 
 func (s *Server) respond(w http.ResponseWriter, req *http.Request, data interface{}, err error) {
@@ -78,14 +87,18 @@ func (s *Server) respond(w http.ResponseWriter, req *http.Request, data interfac
 func NewServerFromConfigOrDie(ctx context.Context, config Config) *Server {
 	cacheCollectionJS := NewJupyterServerCacheCollectionFromConfigOrDie(ctx, config)
 	cacheCollectionAS := NewAmaltheaSessionCacheCollectionFromConfigOrDie(ctx, config)
-	cacheCollectionBR := NewShipwrightBuildRunCacheCollectionFromConfigOrDie(ctx, config)
-	cacheCollectionTR := NewTektonTaskRunCacheCollectionFromConfigOrDie(ctx, config)
+	var cacheCollectionBR *CacheCollection = nil
+	var cacheCollectionTR *CacheCollection = nil
+	if config.ImageBuildersEnabled {
+		cacheCollectionBR = NewShipwrightBuildRunCacheCollectionFromConfigOrDie(ctx, config)
+		cacheCollectionTR = NewTektonTaskRunCacheCollectionFromConfigOrDie(ctx, config)
+	}
 	return &Server{
 		config:   config,
 		cachesJS: *cacheCollectionJS,
 		cachesAS: *cacheCollectionAS,
-		cachesBR: *cacheCollectionBR,
-		cachesTR: *cacheCollectionTR,
+		cachesBR: cacheCollectionBR,
+		cachesTR: cacheCollectionTR,
 		router:   httprouter.New(),
 		Server: &http.Server{
 			Addr: fmt.Sprintf(":%d", config.Port),

--- a/k8s-watcher/server_routes.go
+++ b/k8s-watcher/server_routes.go
@@ -20,11 +20,15 @@ func (s *Server) registerRoutes() {
 	s.router.HandlerFunc("GET", "/users/:userID/sessions", s.asUserID)
 	s.router.HandlerFunc("GET", "/users/:userID/sessions/:serverID", s.asUserIDServerID)
 	// Used for the shipwright operator in charge of image build custom resources
-	s.router.HandlerFunc("GET", "/buildruns", s.brGetAll)
-	s.router.HandlerFunc("GET", "/buildruns/:buildRunID", s.brGetOne)
+	if s.cachesBR != nil {
+		s.router.HandlerFunc("GET", "/buildruns", s.brGetAll)
+		s.router.HandlerFunc("GET", "/buildruns/:buildRunID", s.brGetOne)
+	}
 	// Used for the shipwright operator in charge of image build custom resources
-	s.router.HandlerFunc("GET", "/taskruns", s.trGetAll)
-	s.router.HandlerFunc("GET", "/taskruns/:taskRunID", s.trGetOne)
+	if s.cachesTR != nil {
+		s.router.HandlerFunc("GET", "/taskruns", s.trGetAll)
+		s.router.HandlerFunc("GET", "/taskruns/:taskRunID", s.trGetOne)
+	}
 }
 
 func (s *Server) jsGetAll(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Fixes an issue from #2007.

When image building is not enabled in the RenkuLab instance, do not cache Shipwright BuildRuns and Tekton TaskRuns and do not provide the corresponding API endpoints.

This was already done in a release branch. But it was never merged into master. 