### PR TITLE
feat: create images for amd64 and arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: set up environment variables
       run: |
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
@@ -115,6 +119,7 @@ jobs:
     - name: Push images
       uses: SwissDataScienceCenter/renku-actions/publish-chartpress-images@v1.16.0
       env:
+        PLATFORMS: "linux/amd64,linux/arm64"
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
     - name: Update component version


### PR DESCRIPTION
## Describe your changes

This PR implements building and publishing images for both amd64 and arm64 architecture.

This make renku-notebooks follow other packages such as renku-data-services that are available for both platforms.